### PR TITLE
Upgrade terraform-provider-vultr to v2.23.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,5 @@
-FROM  --platform=linux/amd64 pulumi/pulumi:3.141.0
+FROM  --platform=linux/amd64 pulumi/pulumi:3.142.0
 
-# Install pulumictl and set to PATH
-RUN curl -fsSL https://get.pulumi.com | sh
-ENV PATH="/root/.pulumi/bin:${PATH}"
 
 # create a directory for pulumictl and download the binary to it and set to PATH
 RUN mkdir -p /root/pulumictl && cd /root/pulumictl/
@@ -10,6 +7,7 @@ RUN wget https://github.com/pulumi/pulumictl/releases/download/v0.0.42/pulumictl
 RUN tar -xvf /root/pulumictl/pulumictl-v0.0.42-linux-amd64.tar.gz -C /root/pulumictl/
 ENV PATH="//root/pulumictl/:${PATH}"
 
+RUN apt update
 RUN apt install sudo -y
 
 RUN type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
@@ -18,5 +16,8 @@ RUN sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 RUN sudo apt update
 RUN sudo apt install gh -y
+RUN sudo apt install vim -y
 
 RUN go install github.com/pulumi/upgrade-provider@main
+RUN pip install setuptools
+RUN npm i -g yarn --force

--- a/provider/cmd/pulumi-resource-vultr/schema.json
+++ b/provider/cmd/pulumi-resource-vultr/schema.json
@@ -103,6 +103,10 @@
                     "type": "string",
                     "description": "The managed database's default logical database.\n"
                 },
+                "evictionPolicy": {
+                    "type": "string",
+                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
+                },
                 "ferretdbCredentials": {
                     "type": "object",
                     "additionalProperties": {
@@ -185,10 +189,6 @@
                     "type": "string",
                     "description": "The public hostname assigned to the managed database (VPC-attached only).\n"
                 },
-                "redisEvictionPolicy": {
-                    "type": "string",
-                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
-                },
                 "region": {
                     "type": "string",
                     "description": "The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)\n"
@@ -230,6 +230,7 @@
                         "databaseEngineVersion",
                         "dateCreated",
                         "dbname",
+                        "evictionPolicy",
                         "ferretdbCredentials",
                         "host",
                         "id",
@@ -249,7 +250,6 @@
                         "planVcpus",
                         "port",
                         "publicHost",
-                        "redisEvictionPolicy",
                         "region",
                         "status",
                         "tag",
@@ -262,41 +262,41 @@
         },
         "vultr:index/DatabaseUserAccessControl:DatabaseUserAccessControl": {
             "properties": {
-                "redisAclCategories": {
+                "aclCategories": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "The list of command category rules for this managed database user.\n"
+                    "description": "List of command category rules for this managed database user (Redis engine types only).\n"
                 },
-                "redisAclChannels": {
+                "aclChannels": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "The list of publish/subscribe channel patterns for this managed database user.\n"
+                    "description": "List of publish/subscribe channel patterns for this managed database user (Redis engine types only).\n"
                 },
-                "redisAclCommands": {
+                "aclCommands": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "The list of individual command rules for this managed database user.\n"
+                    "description": "List of individual command rules for this managed database user (Redis engine types only).\n"
                 },
-                "redisAclKeys": {
+                "aclKeys": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "The list of access rules for this managed database user.\n"
+                    "description": "List of access rules for this managed database user (Redis engine types only).\n"
                 }
             },
             "type": "object",
             "required": [
-                "redisAclCategories",
-                "redisAclChannels",
-                "redisAclCommands",
-                "redisAclKeys"
+                "aclCategories",
+                "aclChannels",
+                "aclCommands",
+                "aclKeys"
             ]
         },
         "vultr:index/InstanceBackupsSchedule:InstanceBackupsSchedule": {
@@ -785,6 +785,10 @@
                     "type": "string",
                     "description": "The managed database's default logical database.\n"
                 },
+                "evictionPolicy": {
+                    "type": "string",
+                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only).\n"
+                },
                 "ferretdbCredentials": {
                     "type": "object",
                     "additionalProperties": {
@@ -866,10 +870,6 @@
                     "type": "string",
                     "description": "The public hostname assigned to the managed database (VPC-attached only).\n"
                 },
-                "redisEvictionPolicy": {
-                    "type": "string",
-                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only).\n"
-                },
                 "region": {
                     "type": "string",
                     "description": "The region ID of the managed database.\n"
@@ -905,6 +905,7 @@
                 "databaseEngineVersion",
                 "dateCreated",
                 "dbname",
+                "evictionPolicy",
                 "ferretdbCredentials",
                 "host",
                 "id",
@@ -924,7 +925,6 @@
                 "planVcpus",
                 "port",
                 "publicHost",
-                "redisEvictionPolicy",
                 "region",
                 "status",
                 "tag",
@@ -2472,6 +2472,10 @@
                     "type": "string",
                     "description": "The managed database's default logical database.\n"
                 },
+                "evictionPolicy": {
+                    "type": "string",
+                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
+                },
                 "ferretdbCredentials": {
                     "type": "object",
                     "additionalProperties": {
@@ -2561,10 +2565,6 @@
                     },
                     "description": "A list of read replicas attached to the managed database.\n"
                 },
-                "redisEvictionPolicy": {
-                    "type": "string",
-                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
-                },
                 "region": {
                     "type": "string",
                     "description": "The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)\n"
@@ -2605,6 +2605,7 @@
                 "databaseEngineVersion",
                 "dateCreated",
                 "dbname",
+                "evictionPolicy",
                 "ferretdbCredentials",
                 "host",
                 "label",
@@ -2623,7 +2624,6 @@
                 "port",
                 "publicHost",
                 "readReplicas",
-                "redisEvictionPolicy",
                 "region",
                 "saslPort",
                 "status",
@@ -2650,6 +2650,10 @@
                 "databaseEngineVersion": {
                     "type": "string",
                     "description": "The database engine version of the new managed database.\n"
+                },
+                "evictionPolicy": {
+                    "type": "string",
+                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
                 },
                 "ferretdbCredentials": {
                     "type": "object",
@@ -2720,10 +2724,6 @@
                     },
                     "description": "A list of read replicas attached to the managed database.\n"
                 },
-                "redisEvictionPolicy": {
-                    "type": "string",
-                    "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
-                },
                 "region": {
                     "type": "string",
                     "description": "The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)\n"
@@ -2786,6 +2786,10 @@
                     "dbname": {
                         "type": "string",
                         "description": "The managed database's default logical database.\n"
+                    },
+                    "evictionPolicy": {
+                        "type": "string",
+                        "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
                     },
                     "ferretdbCredentials": {
                         "type": "object",
@@ -2875,10 +2879,6 @@
                             "$ref": "#/types/vultr:index/DatabaseReadReplica:DatabaseReadReplica"
                         },
                         "description": "A list of read replicas attached to the managed database.\n"
-                    },
-                    "redisEvictionPolicy": {
-                        "type": "string",
-                        "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).\n"
                     },
                     "region": {
                         "type": "string",
@@ -3207,6 +3207,10 @@
                     "type": "string",
                     "description": "The managed database read replica's default logical database.\n"
                 },
+                "evictionPolicy": {
+                    "type": "string",
+                    "description": "The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).\n"
+                },
                 "ferretdbCredentials": {
                     "type": "object",
                     "additionalProperties": {
@@ -3285,10 +3289,6 @@
                     "type": "string",
                     "description": "The public hostname assigned to the managed database read replica (VPC-attached only).\n"
                 },
-                "redisEvictionPolicy": {
-                    "type": "string",
-                    "description": "The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).\n"
-                },
                 "region": {
                     "type": "string",
                     "description": "The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)\n"
@@ -3324,6 +3324,7 @@
                 "databaseId",
                 "dateCreated",
                 "dbname",
+                "evictionPolicy",
                 "ferretdbCredentials",
                 "host",
                 "label",
@@ -3342,7 +3343,6 @@
                 "planVcpus",
                 "port",
                 "publicHost",
-                "redisEvictionPolicy",
                 "region",
                 "status",
                 "tag",
@@ -3355,6 +3355,10 @@
                     "type": "string",
                     "description": "The managed database ID you want to attach this replica to.\n",
                     "willReplaceOnChanges": true
+                },
+                "evictionPolicy": {
+                    "type": "string",
+                    "description": "The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).\n"
                 },
                 "ferretdbCredentials": {
                     "type": "object",
@@ -3393,10 +3397,6 @@
                 "publicHost": {
                     "type": "string",
                     "description": "The public hostname assigned to the managed database read replica (VPC-attached only).\n"
-                },
-                "redisEvictionPolicy": {
-                    "type": "string",
-                    "description": "The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).\n"
                 },
                 "region": {
                     "type": "string",
@@ -3446,6 +3446,10 @@
                     "dbname": {
                         "type": "string",
                         "description": "The managed database read replica's default logical database.\n"
+                    },
+                    "evictionPolicy": {
+                        "type": "string",
+                        "description": "The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).\n"
                     },
                     "ferretdbCredentials": {
                         "type": "object",
@@ -3524,10 +3528,6 @@
                     "publicHost": {
                         "type": "string",
                         "description": "The public hostname assigned to the managed database read replica (VPC-attached only).\n"
-                    },
-                    "redisEvictionPolicy": {
-                        "type": "string",
-                        "description": "The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).\n"
                     },
                     "region": {
                         "type": "string",
@@ -5974,7 +5974,7 @@
                 },
                 "description": {
                     "type": "string",
-                    "description": "The description for the given snapshot.\n"
+                    "description": "The description for the given snapshot.\n\nSnapshots often exceed the default timeout built in to all create requests in\nthe provider. In order to customize that, you may specify a custome value in a\n`timeouts` block of the resource definition\n"
                 },
                 "instanceId": {
                     "type": "string",
@@ -6004,7 +6004,7 @@
             "inputProperties": {
                 "description": {
                     "type": "string",
-                    "description": "The description for the given snapshot.\n",
+                    "description": "The description for the given snapshot.\n\nSnapshots often exceed the default timeout built in to all create requests in\nthe provider. In order to customize that, you may specify a custome value in a\n`timeouts` block of the resource definition\n",
                     "willReplaceOnChanges": true
                 },
                 "instanceId": {
@@ -6029,7 +6029,7 @@
                     },
                     "description": {
                         "type": "string",
-                        "description": "The description for the given snapshot.\n",
+                        "description": "The description for the given snapshot.\n\nSnapshots often exceed the default timeout built in to all create requests in\nthe provider. In order to customize that, you may specify a custome value in a\n`timeouts` block of the resource definition\n",
                         "willReplaceOnChanges": true
                     },
                     "instanceId": {
@@ -7119,6 +7119,10 @@
                         "type": "string",
                         "description": "The managed database's default logical database.\n"
                     },
+                    "evictionPolicy": {
+                        "type": "string",
+                        "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only).\n"
+                    },
                     "ferretdbCredentials": {
                         "type": "object",
                         "additionalProperties": {
@@ -7217,10 +7221,6 @@
                         },
                         "description": "A list of read replicas attached to the managed database.\n"
                     },
-                    "redisEvictionPolicy": {
-                        "type": "string",
-                        "description": "The configuration value for the data eviction policy on the managed database (Redis engine types only).\n"
-                    },
                     "region": {
                         "type": "string",
                         "description": "The region ID of the managed database.\n"
@@ -7262,6 +7262,7 @@
                     "databaseEngineVersion",
                     "dateCreated",
                     "dbname",
+                    "evictionPolicy",
                     "ferretdbCredentials",
                     "host",
                     "label",
@@ -7282,7 +7283,6 @@
                     "port",
                     "publicHost",
                     "readReplicas",
-                    "redisEvictionPolicy",
                     "region",
                     "saslPort",
                     "status",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -158,8 +158,8 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/vultr/govultr/v3 v3.11.2 // indirect
-	github.com/vultr/terraform-provider-vultr v1.3.4-0.20241107154417-f537f0001d71 // indirect
+	github.com/vultr/govultr/v3 v3.12.0 // indirect
+	github.com/vultr/terraform-provider-vultr v1.3.4-0.20241206212436-2b7f234ae4fa // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	github.com/zclconf/go-cty v1.15.0 // indirect
@@ -174,7 +174,7 @@ require (
 	golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
+	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/term v0.25.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2007,10 +2007,10 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vultr/govultr/v3 v3.11.2 h1:F3QBuWb9mz3ZOecmVKm31dRAJ5f8fe279+dxZDpS64c=
-github.com/vultr/govultr/v3 v3.11.2/go.mod h1:q34Wd76upKmf+vxFMgaNMH3A8BbsPBmSYZUGC8oZa5w=
-github.com/vultr/terraform-provider-vultr v1.3.4-0.20241107154417-f537f0001d71 h1:43jB4K5uHpYZHlPpOrzjHSSPeyGVh858s3DrxjJ0+pc=
-github.com/vultr/terraform-provider-vultr v1.3.4-0.20241107154417-f537f0001d71/go.mod h1:mi3SGo7vdR3G8h37EXKKzghFMNfddv2XHoMsrTRopb4=
+github.com/vultr/govultr/v3 v3.12.0 h1:nRIm5G8Rr0FA/xWtZ2rT+iV3rSHecS4lXEWMRUXoTpw=
+github.com/vultr/govultr/v3 v3.12.0/go.mod h1:q34Wd76upKmf+vxFMgaNMH3A8BbsPBmSYZUGC8oZa5w=
+github.com/vultr/terraform-provider-vultr v1.3.4-0.20241206212436-2b7f234ae4fa h1:waVmG/WRJVgC23cIkREuVMQkUVlfBFugx+VfgWC248M=
+github.com/vultr/terraform-provider-vultr v1.3.4-0.20241206212436-2b7f234ae4fa/go.mod h1:+X1DqMMJm0Yiz2MbKuH1rhpx+YPYOt0L2EhAPYrWITI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
@@ -2290,8 +2290,8 @@ golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQ
 golang.org/x/oauth2 v0.11.0/go.mod h1:LdF7O/8bLR/qWK9DrpXmbHLTouvRHK0SgJl0GmDBchk=
 golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
 golang.org/x/oauth2 v0.14.0/go.mod h1:lAtNWgaWfL4cm7j2OV8TxGi9Qb7ECORx8DktCY74OwM=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
+golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
-	github.com/vultr/terraform-provider-vultr v1.3.4-0.20241107154417-f537f0001d71
+	github.com/vultr/terraform-provider-vultr v1.3.4-0.20241206212436-2b7f234ae4fa
 )
 
 require (
@@ -37,10 +37,10 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/vultr/govultr/v3 v3.11.2 // indirect
+	github.com/vultr/govultr/v3 v3.12.0 // indirect
 	github.com/zclconf/go-cty v1.15.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
+	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -111,10 +111,10 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vultr/govultr/v3 v3.11.2 h1:F3QBuWb9mz3ZOecmVKm31dRAJ5f8fe279+dxZDpS64c=
-github.com/vultr/govultr/v3 v3.11.2/go.mod h1:q34Wd76upKmf+vxFMgaNMH3A8BbsPBmSYZUGC8oZa5w=
-github.com/vultr/terraform-provider-vultr v1.3.4-0.20241107154417-f537f0001d71 h1:43jB4K5uHpYZHlPpOrzjHSSPeyGVh858s3DrxjJ0+pc=
-github.com/vultr/terraform-provider-vultr v1.3.4-0.20241107154417-f537f0001d71/go.mod h1:mi3SGo7vdR3G8h37EXKKzghFMNfddv2XHoMsrTRopb4=
+github.com/vultr/govultr/v3 v3.12.0 h1:nRIm5G8Rr0FA/xWtZ2rT+iV3rSHecS4lXEWMRUXoTpw=
+github.com/vultr/govultr/v3 v3.12.0/go.mod h1:q34Wd76upKmf+vxFMgaNMH3A8BbsPBmSYZUGC8oZa5w=
+github.com/vultr/terraform-provider-vultr v1.3.4-0.20241206212436-2b7f234ae4fa h1:waVmG/WRJVgC23cIkREuVMQkUVlfBFugx+VfgWC248M=
+github.com/vultr/terraform-provider-vultr v1.3.4-0.20241206212436-2b7f234ae4fa/go.mod h1:+X1DqMMJm0Yiz2MbKuH1rhpx+YPYOt0L2EhAPYrWITI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.15.0 h1:tTCRWxsexYUmtt/wVxgDClUe+uQusuI443uL6e+5sXQ=
 github.com/zclconf/go-cty v1.15.0/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
@@ -133,8 +133,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.28.0 h1:a9JDOJc5GMUJ0+UDqmLT86WiEy7iWyIhz8gz8E4e5hE=
 golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
-golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
-golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
+golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/sdk/dotnet/Database.cs
+++ b/sdk/dotnet/Database.cs
@@ -117,6 +117,12 @@ namespace ediri.Vultr
         public Output<string> Dbname { get; private set; } = null!;
 
         /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        /// </summary>
+        [Output("evictionPolicy")]
+        public Output<string> EvictionPolicy { get; private set; } = null!;
+
+        /// <summary>
         /// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         /// </summary>
         [Output("ferretdbCredentials")]
@@ -237,12 +243,6 @@ namespace ediri.Vultr
         public Output<ImmutableArray<Outputs.DatabaseReadReplica>> ReadReplicas { get; private set; } = null!;
 
         /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        /// </summary>
-        [Output("redisEvictionPolicy")]
-        public Output<string> RedisEvictionPolicy { get; private set; } = null!;
-
-        /// <summary>
         /// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         /// </summary>
         [Output("region")]
@@ -361,6 +361,12 @@ namespace ediri.Vultr
         [Input("databaseEngineVersion", required: true)]
         public Input<string> DatabaseEngineVersion { get; set; } = null!;
 
+        /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        /// </summary>
+        [Input("evictionPolicy")]
+        public Input<string>? EvictionPolicy { get; set; }
+
         [Input("ferretdbCredentials")]
         private InputMap<string>? _ferretdbCredentials;
 
@@ -470,12 +476,6 @@ namespace ediri.Vultr
         }
 
         /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        /// </summary>
-        [Input("redisEvictionPolicy")]
-        public Input<string>? RedisEvictionPolicy { get; set; }
-
-        /// <summary>
         /// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         /// </summary>
         [Input("region", required: true)]
@@ -560,6 +560,12 @@ namespace ediri.Vultr
         /// </summary>
         [Input("dbname")]
         public Input<string>? Dbname { get; set; }
+
+        /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        /// </summary>
+        [Input("evictionPolicy")]
+        public Input<string>? EvictionPolicy { get; set; }
 
         [Input("ferretdbCredentials")]
         private InputMap<string>? _ferretdbCredentials;
@@ -698,12 +704,6 @@ namespace ediri.Vultr
             get => _readReplicas ?? (_readReplicas = new InputList<Inputs.DatabaseReadReplicaGetArgs>());
             set => _readReplicas = value;
         }
-
-        /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        /// </summary>
-        [Input("redisEvictionPolicy")]
-        public Input<string>? RedisEvictionPolicy { get; set; }
 
         /// <summary>
         /// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)

--- a/sdk/dotnet/DatabaseReplica.cs
+++ b/sdk/dotnet/DatabaseReplica.cs
@@ -76,6 +76,12 @@ namespace ediri.Vultr
         public Output<string> Dbname { get; private set; } = null!;
 
         /// <summary>
+        /// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+        /// </summary>
+        [Output("evictionPolicy")]
+        public Output<string> EvictionPolicy { get; private set; } = null!;
+
+        /// <summary>
         /// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         /// </summary>
         [Output("ferretdbCredentials")]
@@ -184,12 +190,6 @@ namespace ediri.Vultr
         public Output<string> PublicHost { get; private set; } = null!;
 
         /// <summary>
-        /// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-        /// </summary>
-        [Output("redisEvictionPolicy")]
-        public Output<string> RedisEvictionPolicy { get; private set; } = null!;
-
-        /// <summary>
         /// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         /// </summary>
         [Output("region")]
@@ -278,6 +278,12 @@ namespace ediri.Vultr
         [Input("databaseId", required: true)]
         public Input<string> DatabaseId { get; set; } = null!;
 
+        /// <summary>
+        /// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+        /// </summary>
+        [Input("evictionPolicy")]
+        public Input<string>? EvictionPolicy { get; set; }
+
         [Input("ferretdbCredentials")]
         private InputMap<string>? _ferretdbCredentials;
 
@@ -337,12 +343,6 @@ namespace ediri.Vultr
         /// </summary>
         [Input("publicHost")]
         public Input<string>? PublicHost { get; set; }
-
-        /// <summary>
-        /// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-        /// </summary>
-        [Input("redisEvictionPolicy")]
-        public Input<string>? RedisEvictionPolicy { get; set; }
 
         /// <summary>
         /// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
@@ -411,6 +411,12 @@ namespace ediri.Vultr
         /// </summary>
         [Input("dbname")]
         public Input<string>? Dbname { get; set; }
+
+        /// <summary>
+        /// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+        /// </summary>
+        [Input("evictionPolicy")]
+        public Input<string>? EvictionPolicy { get; set; }
 
         [Input("ferretdbCredentials")]
         private InputMap<string>? _ferretdbCredentials;
@@ -531,12 +537,6 @@ namespace ediri.Vultr
         /// </summary>
         [Input("publicHost")]
         public Input<string>? PublicHost { get; set; }
-
-        /// <summary>
-        /// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-        /// </summary>
-        [Input("redisEvictionPolicy")]
-        public Input<string>? RedisEvictionPolicy { get; set; }
 
         /// <summary>
         /// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)

--- a/sdk/dotnet/GetDatabase.cs
+++ b/sdk/dotnet/GetDatabase.cs
@@ -159,6 +159,10 @@ namespace ediri.Vultr
         /// </summary>
         public readonly string Dbname;
         /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+        /// </summary>
+        public readonly string EvictionPolicy;
+        /// <summary>
         /// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         /// </summary>
         public readonly ImmutableDictionary<string, string> FerretdbCredentials;
@@ -241,10 +245,6 @@ namespace ediri.Vultr
         /// </summary>
         public readonly ImmutableArray<Outputs.GetDatabaseReadReplicaResult> ReadReplicas;
         /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-        /// </summary>
-        public readonly string RedisEvictionPolicy;
-        /// <summary>
         /// The region ID of the managed database.
         /// </summary>
         public readonly string Region;
@@ -288,6 +288,8 @@ namespace ediri.Vultr
             string dateCreated,
 
             string dbname,
+
+            string evictionPolicy,
 
             ImmutableDictionary<string, string> ferretdbCredentials,
 
@@ -333,8 +335,6 @@ namespace ediri.Vultr
 
             ImmutableArray<Outputs.GetDatabaseReadReplicaResult> readReplicas,
 
-            string redisEvictionPolicy,
-
             string region,
 
             string saslPort,
@@ -356,6 +356,7 @@ namespace ediri.Vultr
             DatabaseEngineVersion = databaseEngineVersion;
             DateCreated = dateCreated;
             Dbname = dbname;
+            EvictionPolicy = evictionPolicy;
             FerretdbCredentials = ferretdbCredentials;
             Filters = filters;
             Host = host;
@@ -378,7 +379,6 @@ namespace ediri.Vultr
             Port = port;
             PublicHost = publicHost;
             ReadReplicas = readReplicas;
-            RedisEvictionPolicy = redisEvictionPolicy;
             Region = region;
             SaslPort = saslPort;
             Status = status;

--- a/sdk/dotnet/Inputs/DatabaseReadReplicaArgs.cs
+++ b/sdk/dotnet/Inputs/DatabaseReadReplicaArgs.cs
@@ -43,6 +43,12 @@ namespace ediri.Vultr.Inputs
         [Input("dbname")]
         public Input<string>? Dbname { get; set; }
 
+        /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        /// </summary>
+        [Input("evictionPolicy")]
+        public Input<string>? EvictionPolicy { get; set; }
+
         [Input("ferretdbCredentials")]
         private InputMap<string>? _ferretdbCredentials;
 
@@ -168,12 +174,6 @@ namespace ediri.Vultr.Inputs
         /// </summary>
         [Input("publicHost")]
         public Input<string>? PublicHost { get; set; }
-
-        /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        /// </summary>
-        [Input("redisEvictionPolicy")]
-        public Input<string>? RedisEvictionPolicy { get; set; }
 
         /// <summary>
         /// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)

--- a/sdk/dotnet/Inputs/DatabaseReadReplicaGetArgs.cs
+++ b/sdk/dotnet/Inputs/DatabaseReadReplicaGetArgs.cs
@@ -43,6 +43,12 @@ namespace ediri.Vultr.Inputs
         [Input("dbname")]
         public Input<string>? Dbname { get; set; }
 
+        /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        /// </summary>
+        [Input("evictionPolicy")]
+        public Input<string>? EvictionPolicy { get; set; }
+
         [Input("ferretdbCredentials")]
         private InputMap<string>? _ferretdbCredentials;
 
@@ -168,12 +174,6 @@ namespace ediri.Vultr.Inputs
         /// </summary>
         [Input("publicHost")]
         public Input<string>? PublicHost { get; set; }
-
-        /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        /// </summary>
-        [Input("redisEvictionPolicy")]
-        public Input<string>? RedisEvictionPolicy { get; set; }
 
         /// <summary>
         /// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)

--- a/sdk/dotnet/Inputs/DatabaseUserAccessControlArgs.cs
+++ b/sdk/dotnet/Inputs/DatabaseUserAccessControlArgs.cs
@@ -13,52 +13,52 @@ namespace ediri.Vultr.Inputs
 
     public sealed class DatabaseUserAccessControlArgs : global::Pulumi.ResourceArgs
     {
-        [Input("redisAclCategories", required: true)]
-        private InputList<string>? _redisAclCategories;
+        [Input("aclCategories", required: true)]
+        private InputList<string>? _aclCategories;
 
         /// <summary>
-        /// The list of command category rules for this managed database user.
+        /// List of command category rules for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclCategories
+        public InputList<string> AclCategories
         {
-            get => _redisAclCategories ?? (_redisAclCategories = new InputList<string>());
-            set => _redisAclCategories = value;
+            get => _aclCategories ?? (_aclCategories = new InputList<string>());
+            set => _aclCategories = value;
         }
 
-        [Input("redisAclChannels", required: true)]
-        private InputList<string>? _redisAclChannels;
+        [Input("aclChannels", required: true)]
+        private InputList<string>? _aclChannels;
 
         /// <summary>
-        /// The list of publish/subscribe channel patterns for this managed database user.
+        /// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclChannels
+        public InputList<string> AclChannels
         {
-            get => _redisAclChannels ?? (_redisAclChannels = new InputList<string>());
-            set => _redisAclChannels = value;
+            get => _aclChannels ?? (_aclChannels = new InputList<string>());
+            set => _aclChannels = value;
         }
 
-        [Input("redisAclCommands", required: true)]
-        private InputList<string>? _redisAclCommands;
+        [Input("aclCommands", required: true)]
+        private InputList<string>? _aclCommands;
 
         /// <summary>
-        /// The list of individual command rules for this managed database user.
+        /// List of individual command rules for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclCommands
+        public InputList<string> AclCommands
         {
-            get => _redisAclCommands ?? (_redisAclCommands = new InputList<string>());
-            set => _redisAclCommands = value;
+            get => _aclCommands ?? (_aclCommands = new InputList<string>());
+            set => _aclCommands = value;
         }
 
-        [Input("redisAclKeys", required: true)]
-        private InputList<string>? _redisAclKeys;
+        [Input("aclKeys", required: true)]
+        private InputList<string>? _aclKeys;
 
         /// <summary>
-        /// The list of access rules for this managed database user.
+        /// List of access rules for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclKeys
+        public InputList<string> AclKeys
         {
-            get => _redisAclKeys ?? (_redisAclKeys = new InputList<string>());
-            set => _redisAclKeys = value;
+            get => _aclKeys ?? (_aclKeys = new InputList<string>());
+            set => _aclKeys = value;
         }
 
         public DatabaseUserAccessControlArgs()

--- a/sdk/dotnet/Inputs/DatabaseUserAccessControlGetArgs.cs
+++ b/sdk/dotnet/Inputs/DatabaseUserAccessControlGetArgs.cs
@@ -13,52 +13,52 @@ namespace ediri.Vultr.Inputs
 
     public sealed class DatabaseUserAccessControlGetArgs : global::Pulumi.ResourceArgs
     {
-        [Input("redisAclCategories", required: true)]
-        private InputList<string>? _redisAclCategories;
+        [Input("aclCategories", required: true)]
+        private InputList<string>? _aclCategories;
 
         /// <summary>
-        /// The list of command category rules for this managed database user.
+        /// List of command category rules for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclCategories
+        public InputList<string> AclCategories
         {
-            get => _redisAclCategories ?? (_redisAclCategories = new InputList<string>());
-            set => _redisAclCategories = value;
+            get => _aclCategories ?? (_aclCategories = new InputList<string>());
+            set => _aclCategories = value;
         }
 
-        [Input("redisAclChannels", required: true)]
-        private InputList<string>? _redisAclChannels;
+        [Input("aclChannels", required: true)]
+        private InputList<string>? _aclChannels;
 
         /// <summary>
-        /// The list of publish/subscribe channel patterns for this managed database user.
+        /// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclChannels
+        public InputList<string> AclChannels
         {
-            get => _redisAclChannels ?? (_redisAclChannels = new InputList<string>());
-            set => _redisAclChannels = value;
+            get => _aclChannels ?? (_aclChannels = new InputList<string>());
+            set => _aclChannels = value;
         }
 
-        [Input("redisAclCommands", required: true)]
-        private InputList<string>? _redisAclCommands;
+        [Input("aclCommands", required: true)]
+        private InputList<string>? _aclCommands;
 
         /// <summary>
-        /// The list of individual command rules for this managed database user.
+        /// List of individual command rules for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclCommands
+        public InputList<string> AclCommands
         {
-            get => _redisAclCommands ?? (_redisAclCommands = new InputList<string>());
-            set => _redisAclCommands = value;
+            get => _aclCommands ?? (_aclCommands = new InputList<string>());
+            set => _aclCommands = value;
         }
 
-        [Input("redisAclKeys", required: true)]
-        private InputList<string>? _redisAclKeys;
+        [Input("aclKeys", required: true)]
+        private InputList<string>? _aclKeys;
 
         /// <summary>
-        /// The list of access rules for this managed database user.
+        /// List of access rules for this managed database user (Redis engine types only).
         /// </summary>
-        public InputList<string> RedisAclKeys
+        public InputList<string> AclKeys
         {
-            get => _redisAclKeys ?? (_redisAclKeys = new InputList<string>());
-            set => _redisAclKeys = value;
+            get => _aclKeys ?? (_aclKeys = new InputList<string>());
+            set => _aclKeys = value;
         }
 
         public DatabaseUserAccessControlGetArgs()

--- a/sdk/dotnet/Outputs/DatabaseReadReplica.cs
+++ b/sdk/dotnet/Outputs/DatabaseReadReplica.cs
@@ -35,6 +35,10 @@ namespace ediri.Vultr.Outputs
         /// </summary>
         public readonly string? Dbname;
         /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        /// </summary>
+        public readonly string? EvictionPolicy;
+        /// <summary>
         /// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         /// </summary>
         public readonly ImmutableDictionary<string, string>? FerretdbCredentials;
@@ -111,10 +115,6 @@ namespace ediri.Vultr.Outputs
         /// </summary>
         public readonly string? PublicHost;
         /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        /// </summary>
-        public readonly string? RedisEvictionPolicy;
-        /// <summary>
         /// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         /// </summary>
         public readonly string Region;
@@ -150,6 +150,8 @@ namespace ediri.Vultr.Outputs
             string? dateCreated,
 
             string? dbname,
+
+            string? evictionPolicy,
 
             ImmutableDictionary<string, string>? ferretdbCredentials,
 
@@ -189,8 +191,6 @@ namespace ediri.Vultr.Outputs
 
             string? publicHost,
 
-            string? redisEvictionPolicy,
-
             string region,
 
             string? status,
@@ -208,6 +208,7 @@ namespace ediri.Vultr.Outputs
             DatabaseEngineVersion = databaseEngineVersion;
             DateCreated = dateCreated;
             Dbname = dbname;
+            EvictionPolicy = evictionPolicy;
             FerretdbCredentials = ferretdbCredentials;
             Host = host;
             Id = id;
@@ -227,7 +228,6 @@ namespace ediri.Vultr.Outputs
             PlanVcpus = planVcpus;
             Port = port;
             PublicHost = publicHost;
-            RedisEvictionPolicy = redisEvictionPolicy;
             Region = region;
             Status = status;
             Tag = tag;

--- a/sdk/dotnet/Outputs/DatabaseUserAccessControl.cs
+++ b/sdk/dotnet/Outputs/DatabaseUserAccessControl.cs
@@ -15,36 +15,36 @@ namespace ediri.Vultr.Outputs
     public sealed class DatabaseUserAccessControl
     {
         /// <summary>
-        /// The list of command category rules for this managed database user.
+        /// List of command category rules for this managed database user (Redis engine types only).
         /// </summary>
-        public readonly ImmutableArray<string> RedisAclCategories;
+        public readonly ImmutableArray<string> AclCategories;
         /// <summary>
-        /// The list of publish/subscribe channel patterns for this managed database user.
+        /// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
         /// </summary>
-        public readonly ImmutableArray<string> RedisAclChannels;
+        public readonly ImmutableArray<string> AclChannels;
         /// <summary>
-        /// The list of individual command rules for this managed database user.
+        /// List of individual command rules for this managed database user (Redis engine types only).
         /// </summary>
-        public readonly ImmutableArray<string> RedisAclCommands;
+        public readonly ImmutableArray<string> AclCommands;
         /// <summary>
-        /// The list of access rules for this managed database user.
+        /// List of access rules for this managed database user (Redis engine types only).
         /// </summary>
-        public readonly ImmutableArray<string> RedisAclKeys;
+        public readonly ImmutableArray<string> AclKeys;
 
         [OutputConstructor]
         private DatabaseUserAccessControl(
-            ImmutableArray<string> redisAclCategories,
+            ImmutableArray<string> aclCategories,
 
-            ImmutableArray<string> redisAclChannels,
+            ImmutableArray<string> aclChannels,
 
-            ImmutableArray<string> redisAclCommands,
+            ImmutableArray<string> aclCommands,
 
-            ImmutableArray<string> redisAclKeys)
+            ImmutableArray<string> aclKeys)
         {
-            RedisAclCategories = redisAclCategories;
-            RedisAclChannels = redisAclChannels;
-            RedisAclCommands = redisAclCommands;
-            RedisAclKeys = redisAclKeys;
+            AclCategories = aclCategories;
+            AclChannels = aclChannels;
+            AclCommands = aclCommands;
+            AclKeys = aclKeys;
         }
     }
 }

--- a/sdk/dotnet/Outputs/GetDatabaseReadReplicaResult.cs
+++ b/sdk/dotnet/Outputs/GetDatabaseReadReplicaResult.cs
@@ -35,6 +35,10 @@ namespace ediri.Vultr.Outputs
         /// </summary>
         public readonly string Dbname;
         /// <summary>
+        /// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+        /// </summary>
+        public readonly string EvictionPolicy;
+        /// <summary>
         /// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         /// </summary>
         public readonly ImmutableDictionary<string, string> FerretdbCredentials;
@@ -108,10 +112,6 @@ namespace ediri.Vultr.Outputs
         /// </summary>
         public readonly string PublicHost;
         /// <summary>
-        /// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-        /// </summary>
-        public readonly string RedisEvictionPolicy;
-        /// <summary>
         /// The region ID of the managed database.
         /// </summary>
         public readonly string Region;
@@ -147,6 +147,8 @@ namespace ediri.Vultr.Outputs
             string dateCreated,
 
             string dbname,
+
+            string evictionPolicy,
 
             ImmutableDictionary<string, string> ferretdbCredentials,
 
@@ -186,8 +188,6 @@ namespace ediri.Vultr.Outputs
 
             string publicHost,
 
-            string redisEvictionPolicy,
-
             string region,
 
             string status,
@@ -205,6 +205,7 @@ namespace ediri.Vultr.Outputs
             DatabaseEngineVersion = databaseEngineVersion;
             DateCreated = dateCreated;
             Dbname = dbname;
+            EvictionPolicy = evictionPolicy;
             FerretdbCredentials = ferretdbCredentials;
             Host = host;
             Id = id;
@@ -224,7 +225,6 @@ namespace ediri.Vultr.Outputs
             PlanVcpus = planVcpus;
             Port = port;
             PublicHost = publicHost;
-            RedisEvictionPolicy = redisEvictionPolicy;
             Region = region;
             Status = status;
             Tag = tag;

--- a/sdk/dotnet/Snapshot.cs
+++ b/sdk/dotnet/Snapshot.cs
@@ -67,6 +67,10 @@ namespace ediri.Vultr
 
         /// <summary>
         /// The description for the given snapshot.
+        /// 
+        /// Snapshots often exceed the default timeout built in to all create requests in
+        /// the provider. In order to customize that, you may specify a custome value in a
+        /// `timeouts` block of the resource definition
         /// </summary>
         [Output("description")]
         public Output<string?> Description { get; private set; } = null!;
@@ -144,6 +148,10 @@ namespace ediri.Vultr
     {
         /// <summary>
         /// The description for the given snapshot.
+        /// 
+        /// Snapshots often exceed the default timeout built in to all create requests in
+        /// the provider. In order to customize that, you may specify a custome value in a
+        /// `timeouts` block of the resource definition
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
@@ -176,6 +184,10 @@ namespace ediri.Vultr
 
         /// <summary>
         /// The description for the given snapshot.
+        /// 
+        /// Snapshots often exceed the default timeout built in to all create requests in
+        /// the provider. In order to customize that, you may specify a custome value in a
+        /// `timeouts` block of the resource definition
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }

--- a/sdk/go/vultr/database.go
+++ b/sdk/go/vultr/database.go
@@ -104,6 +104,8 @@ type Database struct {
 	DateCreated pulumi.StringOutput `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname pulumi.StringOutput `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy pulumi.StringOutput `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapOutput `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database.
@@ -144,8 +146,6 @@ type Database struct {
 	PublicHost pulumi.StringOutput `pulumi:"publicHost"`
 	// A list of read replicas attached to the managed database.
 	ReadReplicas DatabaseReadReplicaArrayOutput `pulumi:"readReplicas"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy pulumi.StringOutput `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringOutput `pulumi:"region"`
 	// The SASL connection port for the managed database (Kafka engine types only).
@@ -221,6 +221,8 @@ type databaseState struct {
 	DateCreated *string `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname *string `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy *string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database.
@@ -261,8 +263,6 @@ type databaseState struct {
 	PublicHost *string `pulumi:"publicHost"`
 	// A list of read replicas attached to the managed database.
 	ReadReplicas []DatabaseReadReplica `pulumi:"readReplicas"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy *string `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region *string `pulumi:"region"`
 	// The SASL connection port for the managed database (Kafka engine types only).
@@ -294,6 +294,8 @@ type DatabaseState struct {
 	DateCreated pulumi.StringPtrInput
 	// The managed database's default logical database.
 	Dbname pulumi.StringPtrInput
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy pulumi.StringPtrInput
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapInput
 	// The hostname assigned to the managed database.
@@ -334,8 +336,6 @@ type DatabaseState struct {
 	PublicHost pulumi.StringPtrInput
 	// A list of read replicas attached to the managed database.
 	ReadReplicas DatabaseReadReplicaArrayInput
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy pulumi.StringPtrInput
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringPtrInput
 	// The SASL connection port for the managed database (Kafka engine types only).
@@ -367,6 +367,8 @@ type databaseArgs struct {
 	DatabaseEngine string `pulumi:"databaseEngine"`
 	// The database engine version of the new managed database.
 	DatabaseEngineVersion string `pulumi:"databaseEngineVersion"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy *string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string `pulumi:"ferretdbCredentials"`
 	// A label for the managed database.
@@ -397,8 +399,6 @@ type databaseArgs struct {
 	PublicHost *string `pulumi:"publicHost"`
 	// A list of read replicas attached to the managed database.
 	ReadReplicas []DatabaseReadReplica `pulumi:"readReplicas"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy *string `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region string `pulumi:"region"`
 	// The SASL connection port for the managed database (Kafka engine types only).
@@ -423,6 +423,8 @@ type DatabaseArgs struct {
 	DatabaseEngine pulumi.StringInput
 	// The database engine version of the new managed database.
 	DatabaseEngineVersion pulumi.StringInput
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy pulumi.StringPtrInput
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapInput
 	// A label for the managed database.
@@ -453,8 +455,6 @@ type DatabaseArgs struct {
 	PublicHost pulumi.StringPtrInput
 	// A list of read replicas attached to the managed database.
 	ReadReplicas DatabaseReadReplicaArrayInput
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy pulumi.StringPtrInput
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringInput
 	// The SASL connection port for the managed database (Kafka engine types only).
@@ -589,6 +589,11 @@ func (o DatabaseOutput) Dbname() pulumi.StringOutput {
 	return o.ApplyT(func(v *Database) pulumi.StringOutput { return v.Dbname }).(pulumi.StringOutput)
 }
 
+// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+func (o DatabaseOutput) EvictionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v *Database) pulumi.StringOutput { return v.EvictionPolicy }).(pulumi.StringOutput)
+}
+
 // An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 func (o DatabaseOutput) FerretdbCredentials() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Database) pulumi.StringMapOutput { return v.FerretdbCredentials }).(pulumi.StringMapOutput)
@@ -687,11 +692,6 @@ func (o DatabaseOutput) PublicHost() pulumi.StringOutput {
 // A list of read replicas attached to the managed database.
 func (o DatabaseOutput) ReadReplicas() DatabaseReadReplicaArrayOutput {
 	return o.ApplyT(func(v *Database) DatabaseReadReplicaArrayOutput { return v.ReadReplicas }).(DatabaseReadReplicaArrayOutput)
-}
-
-// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-func (o DatabaseOutput) RedisEvictionPolicy() pulumi.StringOutput {
-	return o.ApplyT(func(v *Database) pulumi.StringOutput { return v.RedisEvictionPolicy }).(pulumi.StringOutput)
 }
 
 // The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)

--- a/sdk/go/vultr/databaseReplica.go
+++ b/sdk/go/vultr/databaseReplica.go
@@ -59,6 +59,8 @@ type DatabaseReplica struct {
 	DateCreated pulumi.StringOutput `pulumi:"dateCreated"`
 	// The managed database read replica's default logical database.
 	Dbname pulumi.StringOutput `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+	EvictionPolicy pulumi.StringOutput `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapOutput `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database read replica.
@@ -95,8 +97,6 @@ type DatabaseReplica struct {
 	Port pulumi.StringOutput `pulumi:"port"`
 	// The public hostname assigned to the managed database read replica (VPC-attached only).
 	PublicHost pulumi.StringOutput `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-	RedisEvictionPolicy pulumi.StringOutput `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringOutput `pulumi:"region"`
 	// The current status of the managed database read replica (poweroff, rebuilding, rebalancing, configuring, running).
@@ -162,6 +162,8 @@ type databaseReplicaState struct {
 	DateCreated *string `pulumi:"dateCreated"`
 	// The managed database read replica's default logical database.
 	Dbname *string `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+	EvictionPolicy *string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database read replica.
@@ -198,8 +200,6 @@ type databaseReplicaState struct {
 	Port *string `pulumi:"port"`
 	// The public hostname assigned to the managed database read replica (VPC-attached only).
 	PublicHost *string `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-	RedisEvictionPolicy *string `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region *string `pulumi:"region"`
 	// The current status of the managed database read replica (poweroff, rebuilding, rebalancing, configuring, running).
@@ -227,6 +227,8 @@ type DatabaseReplicaState struct {
 	DateCreated pulumi.StringPtrInput
 	// The managed database read replica's default logical database.
 	Dbname pulumi.StringPtrInput
+	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+	EvictionPolicy pulumi.StringPtrInput
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapInput
 	// The hostname assigned to the managed database read replica.
@@ -263,8 +265,6 @@ type DatabaseReplicaState struct {
 	Port pulumi.StringPtrInput
 	// The public hostname assigned to the managed database read replica (VPC-attached only).
 	PublicHost pulumi.StringPtrInput
-	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-	RedisEvictionPolicy pulumi.StringPtrInput
 	// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringPtrInput
 	// The current status of the managed database read replica (poweroff, rebuilding, rebalancing, configuring, running).
@@ -286,6 +286,8 @@ func (DatabaseReplicaState) ElementType() reflect.Type {
 type databaseReplicaArgs struct {
 	// The managed database ID you want to attach this replica to.
 	DatabaseId string `pulumi:"databaseId"`
+	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+	EvictionPolicy *string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string `pulumi:"ferretdbCredentials"`
 	// A label for the managed database read replica.
@@ -302,8 +304,6 @@ type databaseReplicaArgs struct {
 	PlanDisk *int `pulumi:"planDisk"`
 	// The public hostname assigned to the managed database read replica (VPC-attached only).
 	PublicHost *string `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-	RedisEvictionPolicy *string `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region string `pulumi:"region"`
 	// The tag to assign to the managed database read replica.
@@ -316,6 +316,8 @@ type databaseReplicaArgs struct {
 type DatabaseReplicaArgs struct {
 	// The managed database ID you want to attach this replica to.
 	DatabaseId pulumi.StringInput
+	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+	EvictionPolicy pulumi.StringPtrInput
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapInput
 	// A label for the managed database read replica.
@@ -332,8 +334,6 @@ type DatabaseReplicaArgs struct {
 	PlanDisk pulumi.IntPtrInput
 	// The public hostname assigned to the managed database read replica (VPC-attached only).
 	PublicHost pulumi.StringPtrInput
-	// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-	RedisEvictionPolicy pulumi.StringPtrInput
 	// The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringInput
 	// The tag to assign to the managed database read replica.
@@ -459,6 +459,11 @@ func (o DatabaseReplicaOutput) Dbname() pulumi.StringOutput {
 	return o.ApplyT(func(v *DatabaseReplica) pulumi.StringOutput { return v.Dbname }).(pulumi.StringOutput)
 }
 
+// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+func (o DatabaseReplicaOutput) EvictionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v *DatabaseReplica) pulumi.StringOutput { return v.EvictionPolicy }).(pulumi.StringOutput)
+}
+
 // An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 func (o DatabaseReplicaOutput) FerretdbCredentials() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *DatabaseReplica) pulumi.StringMapOutput { return v.FerretdbCredentials }).(pulumi.StringMapOutput)
@@ -547,11 +552,6 @@ func (o DatabaseReplicaOutput) Port() pulumi.StringOutput {
 // The public hostname assigned to the managed database read replica (VPC-attached only).
 func (o DatabaseReplicaOutput) PublicHost() pulumi.StringOutput {
 	return o.ApplyT(func(v *DatabaseReplica) pulumi.StringOutput { return v.PublicHost }).(pulumi.StringOutput)
-}
-
-// The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-func (o DatabaseReplicaOutput) RedisEvictionPolicy() pulumi.StringOutput {
-	return o.ApplyT(func(v *DatabaseReplica) pulumi.StringOutput { return v.RedisEvictionPolicy }).(pulumi.StringOutput)
 }
 
 // The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)

--- a/sdk/go/vultr/getDatabase.go
+++ b/sdk/go/vultr/getDatabase.go
@@ -79,6 +79,8 @@ type LookupDatabaseResult struct {
 	DateCreated string `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname string `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+	EvictionPolicy string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string   `pulumi:"ferretdbCredentials"`
 	Filters             []GetDatabaseFilter `pulumi:"filters"`
@@ -121,8 +123,6 @@ type LookupDatabaseResult struct {
 	PublicHost string `pulumi:"publicHost"`
 	// A list of read replicas attached to the managed database.
 	ReadReplicas []GetDatabaseReadReplica `pulumi:"readReplicas"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-	RedisEvictionPolicy string `pulumi:"redisEvictionPolicy"`
 	// The region ID of the managed database.
 	Region string `pulumi:"region"`
 	// The SASL connection port for the managed database (Kafka engine types only).
@@ -216,6 +216,11 @@ func (o LookupDatabaseResultOutput) DateCreated() pulumi.StringOutput {
 // The managed database's default logical database.
 func (o LookupDatabaseResultOutput) Dbname() pulumi.StringOutput {
 	return o.ApplyT(func(v LookupDatabaseResult) string { return v.Dbname }).(pulumi.StringOutput)
+}
+
+// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+func (o LookupDatabaseResultOutput) EvictionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v LookupDatabaseResult) string { return v.EvictionPolicy }).(pulumi.StringOutput)
 }
 
 // An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
@@ -324,11 +329,6 @@ func (o LookupDatabaseResultOutput) PublicHost() pulumi.StringOutput {
 // A list of read replicas attached to the managed database.
 func (o LookupDatabaseResultOutput) ReadReplicas() GetDatabaseReadReplicaArrayOutput {
 	return o.ApplyT(func(v LookupDatabaseResult) []GetDatabaseReadReplica { return v.ReadReplicas }).(GetDatabaseReadReplicaArrayOutput)
-}
-
-// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-func (o LookupDatabaseResultOutput) RedisEvictionPolicy() pulumi.StringOutput {
-	return o.ApplyT(func(v LookupDatabaseResult) string { return v.RedisEvictionPolicy }).(pulumi.StringOutput)
 }
 
 // The region ID of the managed database.

--- a/sdk/go/vultr/pulumiTypes.go
+++ b/sdk/go/vultr/pulumiTypes.go
@@ -24,6 +24,8 @@ type DatabaseReadReplica struct {
 	DateCreated *string `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname *string `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy *string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database.
@@ -62,8 +64,6 @@ type DatabaseReadReplica struct {
 	Port *string `pulumi:"port"`
 	// The public hostname assigned to the managed database (VPC-attached only).
 	PublicHost *string `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy *string `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region string `pulumi:"region"`
 	// The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -100,6 +100,8 @@ type DatabaseReadReplicaArgs struct {
 	DateCreated pulumi.StringPtrInput `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname pulumi.StringPtrInput `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+	EvictionPolicy pulumi.StringPtrInput `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapInput `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database.
@@ -138,8 +140,6 @@ type DatabaseReadReplicaArgs struct {
 	Port pulumi.StringPtrInput `pulumi:"port"`
 	// The public hostname assigned to the managed database (VPC-attached only).
 	PublicHost pulumi.StringPtrInput `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-	RedisEvictionPolicy pulumi.StringPtrInput `pulumi:"redisEvictionPolicy"`
 	// The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 	Region pulumi.StringInput `pulumi:"region"`
 	// The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -228,6 +228,11 @@ func (o DatabaseReadReplicaOutput) DateCreated() pulumi.StringPtrOutput {
 // The managed database's default logical database.
 func (o DatabaseReadReplicaOutput) Dbname() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DatabaseReadReplica) *string { return v.Dbname }).(pulumi.StringPtrOutput)
+}
+
+// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+func (o DatabaseReadReplicaOutput) EvictionPolicy() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v DatabaseReadReplica) *string { return v.EvictionPolicy }).(pulumi.StringPtrOutput)
 }
 
 // An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
@@ -325,11 +330,6 @@ func (o DatabaseReadReplicaOutput) PublicHost() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v DatabaseReadReplica) *string { return v.PublicHost }).(pulumi.StringPtrOutput)
 }
 
-// The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-func (o DatabaseReadReplicaOutput) RedisEvictionPolicy() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v DatabaseReadReplica) *string { return v.RedisEvictionPolicy }).(pulumi.StringPtrOutput)
-}
-
 // The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
 func (o DatabaseReadReplicaOutput) Region() pulumi.StringOutput {
 	return o.ApplyT(func(v DatabaseReadReplica) string { return v.Region }).(pulumi.StringOutput)
@@ -381,14 +381,14 @@ func (o DatabaseReadReplicaArrayOutput) Index(i pulumi.IntInput) DatabaseReadRep
 }
 
 type DatabaseUserAccessControl struct {
-	// The list of command category rules for this managed database user.
-	RedisAclCategories []string `pulumi:"redisAclCategories"`
-	// The list of publish/subscribe channel patterns for this managed database user.
-	RedisAclChannels []string `pulumi:"redisAclChannels"`
-	// The list of individual command rules for this managed database user.
-	RedisAclCommands []string `pulumi:"redisAclCommands"`
-	// The list of access rules for this managed database user.
-	RedisAclKeys []string `pulumi:"redisAclKeys"`
+	// List of command category rules for this managed database user (Redis engine types only).
+	AclCategories []string `pulumi:"aclCategories"`
+	// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+	AclChannels []string `pulumi:"aclChannels"`
+	// List of individual command rules for this managed database user (Redis engine types only).
+	AclCommands []string `pulumi:"aclCommands"`
+	// List of access rules for this managed database user (Redis engine types only).
+	AclKeys []string `pulumi:"aclKeys"`
 }
 
 // DatabaseUserAccessControlInput is an input type that accepts DatabaseUserAccessControlArgs and DatabaseUserAccessControlOutput values.
@@ -403,14 +403,14 @@ type DatabaseUserAccessControlInput interface {
 }
 
 type DatabaseUserAccessControlArgs struct {
-	// The list of command category rules for this managed database user.
-	RedisAclCategories pulumi.StringArrayInput `pulumi:"redisAclCategories"`
-	// The list of publish/subscribe channel patterns for this managed database user.
-	RedisAclChannels pulumi.StringArrayInput `pulumi:"redisAclChannels"`
-	// The list of individual command rules for this managed database user.
-	RedisAclCommands pulumi.StringArrayInput `pulumi:"redisAclCommands"`
-	// The list of access rules for this managed database user.
-	RedisAclKeys pulumi.StringArrayInput `pulumi:"redisAclKeys"`
+	// List of command category rules for this managed database user (Redis engine types only).
+	AclCategories pulumi.StringArrayInput `pulumi:"aclCategories"`
+	// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+	AclChannels pulumi.StringArrayInput `pulumi:"aclChannels"`
+	// List of individual command rules for this managed database user (Redis engine types only).
+	AclCommands pulumi.StringArrayInput `pulumi:"aclCommands"`
+	// List of access rules for this managed database user (Redis engine types only).
+	AclKeys pulumi.StringArrayInput `pulumi:"aclKeys"`
 }
 
 func (DatabaseUserAccessControlArgs) ElementType() reflect.Type {
@@ -490,24 +490,24 @@ func (o DatabaseUserAccessControlOutput) ToDatabaseUserAccessControlPtrOutputWit
 	}).(DatabaseUserAccessControlPtrOutput)
 }
 
-// The list of command category rules for this managed database user.
-func (o DatabaseUserAccessControlOutput) RedisAclCategories() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.RedisAclCategories }).(pulumi.StringArrayOutput)
+// List of command category rules for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlOutput) AclCategories() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.AclCategories }).(pulumi.StringArrayOutput)
 }
 
-// The list of publish/subscribe channel patterns for this managed database user.
-func (o DatabaseUserAccessControlOutput) RedisAclChannels() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.RedisAclChannels }).(pulumi.StringArrayOutput)
+// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlOutput) AclChannels() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.AclChannels }).(pulumi.StringArrayOutput)
 }
 
-// The list of individual command rules for this managed database user.
-func (o DatabaseUserAccessControlOutput) RedisAclCommands() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.RedisAclCommands }).(pulumi.StringArrayOutput)
+// List of individual command rules for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlOutput) AclCommands() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.AclCommands }).(pulumi.StringArrayOutput)
 }
 
-// The list of access rules for this managed database user.
-func (o DatabaseUserAccessControlOutput) RedisAclKeys() pulumi.StringArrayOutput {
-	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.RedisAclKeys }).(pulumi.StringArrayOutput)
+// List of access rules for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlOutput) AclKeys() pulumi.StringArrayOutput {
+	return o.ApplyT(func(v DatabaseUserAccessControl) []string { return v.AclKeys }).(pulumi.StringArrayOutput)
 }
 
 type DatabaseUserAccessControlPtrOutput struct{ *pulumi.OutputState }
@@ -534,43 +534,43 @@ func (o DatabaseUserAccessControlPtrOutput) Elem() DatabaseUserAccessControlOutp
 	}).(DatabaseUserAccessControlOutput)
 }
 
-// The list of command category rules for this managed database user.
-func (o DatabaseUserAccessControlPtrOutput) RedisAclCategories() pulumi.StringArrayOutput {
+// List of command category rules for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlPtrOutput) AclCategories() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *DatabaseUserAccessControl) []string {
 		if v == nil {
 			return nil
 		}
-		return v.RedisAclCategories
+		return v.AclCategories
 	}).(pulumi.StringArrayOutput)
 }
 
-// The list of publish/subscribe channel patterns for this managed database user.
-func (o DatabaseUserAccessControlPtrOutput) RedisAclChannels() pulumi.StringArrayOutput {
+// List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlPtrOutput) AclChannels() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *DatabaseUserAccessControl) []string {
 		if v == nil {
 			return nil
 		}
-		return v.RedisAclChannels
+		return v.AclChannels
 	}).(pulumi.StringArrayOutput)
 }
 
-// The list of individual command rules for this managed database user.
-func (o DatabaseUserAccessControlPtrOutput) RedisAclCommands() pulumi.StringArrayOutput {
+// List of individual command rules for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlPtrOutput) AclCommands() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *DatabaseUserAccessControl) []string {
 		if v == nil {
 			return nil
 		}
-		return v.RedisAclCommands
+		return v.AclCommands
 	}).(pulumi.StringArrayOutput)
 }
 
-// The list of access rules for this managed database user.
-func (o DatabaseUserAccessControlPtrOutput) RedisAclKeys() pulumi.StringArrayOutput {
+// List of access rules for this managed database user (Redis engine types only).
+func (o DatabaseUserAccessControlPtrOutput) AclKeys() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *DatabaseUserAccessControl) []string {
 		if v == nil {
 			return nil
 		}
-		return v.RedisAclKeys
+		return v.AclKeys
 	}).(pulumi.StringArrayOutput)
 }
 
@@ -2822,6 +2822,8 @@ type GetDatabaseReadReplica struct {
 	DateCreated string `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname string `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+	EvictionPolicy string `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials map[string]string `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database.
@@ -2859,8 +2861,6 @@ type GetDatabaseReadReplica struct {
 	Port string `pulumi:"port"`
 	// The public hostname assigned to the managed database (VPC-attached only).
 	PublicHost string `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-	RedisEvictionPolicy string `pulumi:"redisEvictionPolicy"`
 	// The region ID of the managed database.
 	Region string `pulumi:"region"`
 	// The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -2897,6 +2897,8 @@ type GetDatabaseReadReplicaArgs struct {
 	DateCreated pulumi.StringInput `pulumi:"dateCreated"`
 	// The managed database's default logical database.
 	Dbname pulumi.StringInput `pulumi:"dbname"`
+	// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+	EvictionPolicy pulumi.StringInput `pulumi:"evictionPolicy"`
 	// An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
 	FerretdbCredentials pulumi.StringMapInput `pulumi:"ferretdbCredentials"`
 	// The hostname assigned to the managed database.
@@ -2934,8 +2936,6 @@ type GetDatabaseReadReplicaArgs struct {
 	Port pulumi.StringInput `pulumi:"port"`
 	// The public hostname assigned to the managed database (VPC-attached only).
 	PublicHost pulumi.StringInput `pulumi:"publicHost"`
-	// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-	RedisEvictionPolicy pulumi.StringInput `pulumi:"redisEvictionPolicy"`
 	// The region ID of the managed database.
 	Region pulumi.StringInput `pulumi:"region"`
 	// The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -3024,6 +3024,11 @@ func (o GetDatabaseReadReplicaOutput) DateCreated() pulumi.StringOutput {
 // The managed database's default logical database.
 func (o GetDatabaseReadReplicaOutput) Dbname() pulumi.StringOutput {
 	return o.ApplyT(func(v GetDatabaseReadReplica) string { return v.Dbname }).(pulumi.StringOutput)
+}
+
+// The configuration value for the data eviction policy on the managed database (Redis engine types only).
+func (o GetDatabaseReadReplicaOutput) EvictionPolicy() pulumi.StringOutput {
+	return o.ApplyT(func(v GetDatabaseReadReplica) string { return v.EvictionPolicy }).(pulumi.StringOutput)
 }
 
 // An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
@@ -3118,11 +3123,6 @@ func (o GetDatabaseReadReplicaOutput) Port() pulumi.StringOutput {
 // The public hostname assigned to the managed database (VPC-attached only).
 func (o GetDatabaseReadReplicaOutput) PublicHost() pulumi.StringOutput {
 	return o.ApplyT(func(v GetDatabaseReadReplica) string { return v.PublicHost }).(pulumi.StringOutput)
-}
-
-// The configuration value for the data eviction policy on the managed database (Redis engine types only).
-func (o GetDatabaseReadReplicaOutput) RedisEvictionPolicy() pulumi.StringOutput {
-	return o.ApplyT(func(v GetDatabaseReadReplica) string { return v.RedisEvictionPolicy }).(pulumi.StringOutput)
 }
 
 // The region ID of the managed database.

--- a/sdk/go/vultr/snapshot.go
+++ b/sdk/go/vultr/snapshot.go
@@ -67,6 +67,10 @@ type Snapshot struct {
 	// The date the snapshot was created.
 	DateCreated pulumi.StringOutput `pulumi:"dateCreated"`
 	// The description for the given snapshot.
+	//
+	// Snapshots often exceed the default timeout built in to all create requests in
+	// the provider. In order to customize that, you may specify a custome value in a
+	// `timeouts` block of the resource definition
 	Description pulumi.StringPtrOutput `pulumi:"description"`
 	// ID of a given instance that you want to create a snapshot from.
 	InstanceId pulumi.StringOutput `pulumi:"instanceId"`
@@ -116,6 +120,10 @@ type snapshotState struct {
 	// The date the snapshot was created.
 	DateCreated *string `pulumi:"dateCreated"`
 	// The description for the given snapshot.
+	//
+	// Snapshots often exceed the default timeout built in to all create requests in
+	// the provider. In order to customize that, you may specify a custome value in a
+	// `timeouts` block of the resource definition
 	Description *string `pulumi:"description"`
 	// ID of a given instance that you want to create a snapshot from.
 	InstanceId *string `pulumi:"instanceId"`
@@ -133,6 +141,10 @@ type SnapshotState struct {
 	// The date the snapshot was created.
 	DateCreated pulumi.StringPtrInput
 	// The description for the given snapshot.
+	//
+	// Snapshots often exceed the default timeout built in to all create requests in
+	// the provider. In order to customize that, you may specify a custome value in a
+	// `timeouts` block of the resource definition
 	Description pulumi.StringPtrInput
 	// ID of a given instance that you want to create a snapshot from.
 	InstanceId pulumi.StringPtrInput
@@ -150,6 +162,10 @@ func (SnapshotState) ElementType() reflect.Type {
 
 type snapshotArgs struct {
 	// The description for the given snapshot.
+	//
+	// Snapshots often exceed the default timeout built in to all create requests in
+	// the provider. In order to customize that, you may specify a custome value in a
+	// `timeouts` block of the resource definition
 	Description *string `pulumi:"description"`
 	// ID of a given instance that you want to create a snapshot from.
 	InstanceId string `pulumi:"instanceId"`
@@ -158,6 +174,10 @@ type snapshotArgs struct {
 // The set of arguments for constructing a Snapshot resource.
 type SnapshotArgs struct {
 	// The description for the given snapshot.
+	//
+	// Snapshots often exceed the default timeout built in to all create requests in
+	// the provider. In order to customize that, you may specify a custome value in a
+	// `timeouts` block of the resource definition
 	Description pulumi.StringPtrInput
 	// ID of a given instance that you want to create a snapshot from.
 	InstanceId pulumi.StringInput
@@ -261,6 +281,10 @@ func (o SnapshotOutput) DateCreated() pulumi.StringOutput {
 }
 
 // The description for the given snapshot.
+//
+// Snapshots often exceed the default timeout built in to all create requests in
+// the provider. In order to customize that, you may specify a custome value in a
+// `timeouts` block of the resource definition
 func (o SnapshotOutput) Description() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Snapshot) pulumi.StringPtrOutput { return v.Description }).(pulumi.StringPtrOutput)
 }

--- a/sdk/nodejs/database.ts
+++ b/sdk/nodejs/database.ts
@@ -110,6 +110,10 @@ export class Database extends pulumi.CustomResource {
      */
     public /*out*/ readonly dbname!: pulumi.Output<string>;
     /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+     */
+    public readonly evictionPolicy!: pulumi.Output<string>;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     public readonly ferretdbCredentials!: pulumi.Output<{[key: string]: string}>;
@@ -190,10 +194,6 @@ export class Database extends pulumi.CustomResource {
      */
     public readonly readReplicas!: pulumi.Output<outputs.DatabaseReadReplica[]>;
     /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-     */
-    public readonly redisEvictionPolicy!: pulumi.Output<string>;
-    /**
      * The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */
     public readonly region!: pulumi.Output<string>;
@@ -242,6 +242,7 @@ export class Database extends pulumi.CustomResource {
             resourceInputs["databaseEngineVersion"] = state ? state.databaseEngineVersion : undefined;
             resourceInputs["dateCreated"] = state ? state.dateCreated : undefined;
             resourceInputs["dbname"] = state ? state.dbname : undefined;
+            resourceInputs["evictionPolicy"] = state ? state.evictionPolicy : undefined;
             resourceInputs["ferretdbCredentials"] = state ? state.ferretdbCredentials : undefined;
             resourceInputs["host"] = state ? state.host : undefined;
             resourceInputs["label"] = state ? state.label : undefined;
@@ -262,7 +263,6 @@ export class Database extends pulumi.CustomResource {
             resourceInputs["port"] = state ? state.port : undefined;
             resourceInputs["publicHost"] = state ? state.publicHost : undefined;
             resourceInputs["readReplicas"] = state ? state.readReplicas : undefined;
-            resourceInputs["redisEvictionPolicy"] = state ? state.redisEvictionPolicy : undefined;
             resourceInputs["region"] = state ? state.region : undefined;
             resourceInputs["saslPort"] = state ? state.saslPort : undefined;
             resourceInputs["status"] = state ? state.status : undefined;
@@ -292,6 +292,7 @@ export class Database extends pulumi.CustomResource {
             resourceInputs["clusterTimeZone"] = args ? args.clusterTimeZone : undefined;
             resourceInputs["databaseEngine"] = args ? args.databaseEngine : undefined;
             resourceInputs["databaseEngineVersion"] = args ? args.databaseEngineVersion : undefined;
+            resourceInputs["evictionPolicy"] = args ? args.evictionPolicy : undefined;
             resourceInputs["ferretdbCredentials"] = args ? args.ferretdbCredentials : undefined;
             resourceInputs["label"] = args ? args.label : undefined;
             resourceInputs["maintenanceDow"] = args ? args.maintenanceDow : undefined;
@@ -307,7 +308,6 @@ export class Database extends pulumi.CustomResource {
             resourceInputs["planReplicas"] = args ? args.planReplicas : undefined;
             resourceInputs["publicHost"] = args ? args.publicHost : undefined;
             resourceInputs["readReplicas"] = args ? args.readReplicas : undefined;
-            resourceInputs["redisEvictionPolicy"] = args ? args.redisEvictionPolicy : undefined;
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["saslPort"] = args ? args.saslPort : undefined;
             resourceInputs["tag"] = args ? args.tag : undefined;
@@ -360,6 +360,10 @@ export interface DatabaseState {
      * The managed database's default logical database.
      */
     dbname?: pulumi.Input<string>;
+    /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+     */
+    evictionPolicy?: pulumi.Input<string>;
     /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
@@ -441,10 +445,6 @@ export interface DatabaseState {
      */
     readReplicas?: pulumi.Input<pulumi.Input<inputs.DatabaseReadReplica>[]>;
     /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-     */
-    redisEvictionPolicy?: pulumi.Input<string>;
-    /**
      * The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */
     region?: pulumi.Input<string>;
@@ -498,6 +498,10 @@ export interface DatabaseArgs {
      * The database engine version of the new managed database.
      */
     databaseEngineVersion: pulumi.Input<string>;
+    /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+     */
+    evictionPolicy?: pulumi.Input<string>;
     /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
@@ -558,10 +562,6 @@ export interface DatabaseArgs {
      * A list of read replicas attached to the managed database.
      */
     readReplicas?: pulumi.Input<pulumi.Input<inputs.DatabaseReadReplica>[]>;
-    /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-     */
-    redisEvictionPolicy?: pulumi.Input<string>;
     /**
      * The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */

--- a/sdk/nodejs/databaseReplica.ts
+++ b/sdk/nodejs/databaseReplica.ts
@@ -76,6 +76,10 @@ export class DatabaseReplica extends pulumi.CustomResource {
      */
     public /*out*/ readonly dbname!: pulumi.Output<string>;
     /**
+     * The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+     */
+    public readonly evictionPolicy!: pulumi.Output<string>;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     public readonly ferretdbCredentials!: pulumi.Output<{[key: string]: string}>;
@@ -148,10 +152,6 @@ export class DatabaseReplica extends pulumi.CustomResource {
      */
     public readonly publicHost!: pulumi.Output<string>;
     /**
-     * The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-     */
-    public readonly redisEvictionPolicy!: pulumi.Output<string>;
-    /**
      * The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */
     public readonly region!: pulumi.Output<string>;
@@ -195,6 +195,7 @@ export class DatabaseReplica extends pulumi.CustomResource {
             resourceInputs["databaseId"] = state ? state.databaseId : undefined;
             resourceInputs["dateCreated"] = state ? state.dateCreated : undefined;
             resourceInputs["dbname"] = state ? state.dbname : undefined;
+            resourceInputs["evictionPolicy"] = state ? state.evictionPolicy : undefined;
             resourceInputs["ferretdbCredentials"] = state ? state.ferretdbCredentials : undefined;
             resourceInputs["host"] = state ? state.host : undefined;
             resourceInputs["label"] = state ? state.label : undefined;
@@ -213,7 +214,6 @@ export class DatabaseReplica extends pulumi.CustomResource {
             resourceInputs["planVcpus"] = state ? state.planVcpus : undefined;
             resourceInputs["port"] = state ? state.port : undefined;
             resourceInputs["publicHost"] = state ? state.publicHost : undefined;
-            resourceInputs["redisEvictionPolicy"] = state ? state.redisEvictionPolicy : undefined;
             resourceInputs["region"] = state ? state.region : undefined;
             resourceInputs["status"] = state ? state.status : undefined;
             resourceInputs["tag"] = state ? state.tag : undefined;
@@ -232,6 +232,7 @@ export class DatabaseReplica extends pulumi.CustomResource {
                 throw new Error("Missing required property 'region'");
             }
             resourceInputs["databaseId"] = args ? args.databaseId : undefined;
+            resourceInputs["evictionPolicy"] = args ? args.evictionPolicy : undefined;
             resourceInputs["ferretdbCredentials"] = args ? args.ferretdbCredentials : undefined;
             resourceInputs["label"] = args ? args.label : undefined;
             resourceInputs["mysqlLongQueryTime"] = args ? args.mysqlLongQueryTime : undefined;
@@ -240,7 +241,6 @@ export class DatabaseReplica extends pulumi.CustomResource {
             resourceInputs["mysqlSqlModes"] = args ? args.mysqlSqlModes : undefined;
             resourceInputs["planDisk"] = args ? args.planDisk : undefined;
             resourceInputs["publicHost"] = args ? args.publicHost : undefined;
-            resourceInputs["redisEvictionPolicy"] = args ? args.redisEvictionPolicy : undefined;
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["tag"] = args ? args.tag : undefined;
             resourceInputs["trustedIps"] = args ? args.trustedIps : undefined;
@@ -296,6 +296,10 @@ export interface DatabaseReplicaState {
      * The managed database read replica's default logical database.
      */
     dbname?: pulumi.Input<string>;
+    /**
+     * The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+     */
+    evictionPolicy?: pulumi.Input<string>;
     /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
@@ -369,10 +373,6 @@ export interface DatabaseReplicaState {
      */
     publicHost?: pulumi.Input<string>;
     /**
-     * The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-     */
-    redisEvictionPolicy?: pulumi.Input<string>;
-    /**
      * The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */
     region?: pulumi.Input<string>;
@@ -407,6 +407,10 @@ export interface DatabaseReplicaArgs {
      */
     databaseId: pulumi.Input<string>;
     /**
+     * The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+     */
+    evictionPolicy?: pulumi.Input<string>;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     ferretdbCredentials?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
@@ -438,10 +442,6 @@ export interface DatabaseReplicaArgs {
      * The public hostname assigned to the managed database read replica (VPC-attached only).
      */
     publicHost?: pulumi.Input<string>;
-    /**
-     * The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-     */
-    redisEvictionPolicy?: pulumi.Input<string>;
     /**
      * The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */

--- a/sdk/nodejs/getDatabase.ts
+++ b/sdk/nodejs/getDatabase.ts
@@ -76,6 +76,10 @@ export interface GetDatabaseResult {
      */
     readonly dbname: string;
     /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only).
+     */
+    readonly evictionPolicy: string;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     readonly ferretdbCredentials: {[key: string]: string};
@@ -157,10 +161,6 @@ export interface GetDatabaseResult {
      * A list of read replicas attached to the managed database.
      */
     readonly readReplicas: outputs.GetDatabaseReadReplica[];
-    /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only).
-     */
-    readonly redisEvictionPolicy: string;
     /**
      * The region ID of the managed database.
      */

--- a/sdk/nodejs/snapshot.ts
+++ b/sdk/nodejs/snapshot.ts
@@ -73,6 +73,10 @@ export class Snapshot extends pulumi.CustomResource {
     public /*out*/ readonly dateCreated!: pulumi.Output<string>;
     /**
      * The description for the given snapshot.
+     *
+     * Snapshots often exceed the default timeout built in to all create requests in
+     * the provider. In order to customize that, you may specify a custome value in a
+     * `timeouts` block of the resource definition
      */
     public readonly description!: pulumi.Output<string | undefined>;
     /**
@@ -144,6 +148,10 @@ export interface SnapshotState {
     dateCreated?: pulumi.Input<string>;
     /**
      * The description for the given snapshot.
+     *
+     * Snapshots often exceed the default timeout built in to all create requests in
+     * the provider. In order to customize that, you may specify a custome value in a
+     * `timeouts` block of the resource definition
      */
     description?: pulumi.Input<string>;
     /**
@@ -170,6 +178,10 @@ export interface SnapshotState {
 export interface SnapshotArgs {
     /**
      * The description for the given snapshot.
+     *
+     * Snapshots often exceed the default timeout built in to all create requests in
+     * the provider. In order to customize that, you may specify a custome value in a
+     * `timeouts` block of the resource definition
      */
     description?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -27,6 +27,10 @@ export interface DatabaseReadReplica {
      */
     dbname?: pulumi.Input<string>;
     /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+     */
+    evictionPolicy?: pulumi.Input<string>;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     ferretdbCredentials?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
@@ -103,10 +107,6 @@ export interface DatabaseReadReplica {
      */
     publicHost?: pulumi.Input<string>;
     /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-     */
-    redisEvictionPolicy?: pulumi.Input<string>;
-    /**
      * The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */
     region: pulumi.Input<string>;
@@ -134,21 +134,21 @@ export interface DatabaseReadReplica {
 
 export interface DatabaseUserAccessControl {
     /**
-     * The list of command category rules for this managed database user.
+     * List of command category rules for this managed database user (Redis engine types only).
      */
-    redisAclCategories: pulumi.Input<pulumi.Input<string>[]>;
+    aclCategories: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * The list of publish/subscribe channel patterns for this managed database user.
+     * List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
      */
-    redisAclChannels: pulumi.Input<pulumi.Input<string>[]>;
+    aclChannels: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * The list of individual command rules for this managed database user.
+     * List of individual command rules for this managed database user (Redis engine types only).
      */
-    redisAclCommands: pulumi.Input<pulumi.Input<string>[]>;
+    aclCommands: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * The list of access rules for this managed database user.
+     * List of access rules for this managed database user (Redis engine types only).
      */
-    redisAclKeys: pulumi.Input<pulumi.Input<string>[]>;
+    aclKeys: pulumi.Input<pulumi.Input<string>[]>;
 }
 
 export interface GetApplicationFilter {

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -27,6 +27,10 @@ export interface DatabaseReadReplica {
      */
     dbname: string;
     /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+     */
+    evictionPolicy: string;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     ferretdbCredentials: {[key: string]: string};
@@ -103,10 +107,6 @@ export interface DatabaseReadReplica {
      */
     publicHost: string;
     /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-     */
-    redisEvictionPolicy: string;
-    /**
      * The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
      */
     region: string;
@@ -134,21 +134,21 @@ export interface DatabaseReadReplica {
 
 export interface DatabaseUserAccessControl {
     /**
-     * The list of command category rules for this managed database user.
+     * List of command category rules for this managed database user (Redis engine types only).
      */
-    redisAclCategories: string[];
+    aclCategories: string[];
     /**
-     * The list of publish/subscribe channel patterns for this managed database user.
+     * List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
      */
-    redisAclChannels: string[];
+    aclChannels: string[];
     /**
-     * The list of individual command rules for this managed database user.
+     * List of individual command rules for this managed database user (Redis engine types only).
      */
-    redisAclCommands: string[];
+    aclCommands: string[];
     /**
-     * The list of access rules for this managed database user.
+     * List of access rules for this managed database user (Redis engine types only).
      */
-    redisAclKeys: string[];
+    aclKeys: string[];
 }
 
 export interface GetApplicationFilter {
@@ -281,6 +281,10 @@ export interface GetDatabaseReadReplica {
      */
     dbname: string;
     /**
+     * The configuration value for the data eviction policy on the managed database (Redis engine types only).
+     */
+    evictionPolicy: string;
+    /**
      * An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
      */
     ferretdbCredentials: {[key: string]: string};
@@ -353,10 +357,6 @@ export interface GetDatabaseReadReplica {
      * The public hostname assigned to the managed database (VPC-attached only).
      */
     publicHost: string;
-    /**
-     * The configuration value for the data eviction policy on the managed database (Redis engine types only).
-     */
-    redisEvictionPolicy: string;
     /**
      * The region ID of the managed database.
      */

--- a/sdk/python/ediri_vultr/_inputs.py
+++ b/sdk/python/ediri_vultr/_inputs.py
@@ -127,6 +127,10 @@ if not MYPY:
         """
         The managed database's default logical database.
         """
+        eviction_policy: NotRequired[pulumi.Input[str]]
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        """
         ferretdb_credentials: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         """
         An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
@@ -199,10 +203,6 @@ if not MYPY:
         """
         The public hostname assigned to the managed database (VPC-attached only).
         """
-        redis_eviction_policy: NotRequired[pulumi.Input[str]]
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        """
         status: NotRequired[pulumi.Input[str]]
         """
         The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -236,6 +236,7 @@ class DatabaseReadReplicaArgs:
                  database_engine_version: Optional[pulumi.Input[str]] = None,
                  date_created: Optional[pulumi.Input[str]] = None,
                  dbname: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  host: Optional[pulumi.Input[str]] = None,
                  id: Optional[pulumi.Input[str]] = None,
@@ -254,7 +255,6 @@ class DatabaseReadReplicaArgs:
                  plan_vcpus: Optional[pulumi.Input[int]] = None,
                  port: Optional[pulumi.Input[str]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  status: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
                  trusted_ips: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -268,6 +268,7 @@ class DatabaseReadReplicaArgs:
         :param pulumi.Input[str] database_engine_version: The database engine version of the new managed database.
         :param pulumi.Input[str] date_created: The date the managed database was added to your Vultr account.
         :param pulumi.Input[str] dbname: The managed database's default logical database.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] host: The hostname assigned to the managed database.
         :param pulumi.Input[str] id: The ID of the managed database.
@@ -286,7 +287,6 @@ class DatabaseReadReplicaArgs:
         :param pulumi.Input[int] plan_vcpus: The number of virtual CPUs available on the managed database.
         :param pulumi.Input[str] port: The connection port for the managed database.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database (VPC-attached only).
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[str] status: The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
         :param pulumi.Input[str] tag: The tag to assign to the managed database.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] trusted_ips: A list of allowed IP addresses for the managed database.
@@ -305,6 +305,8 @@ class DatabaseReadReplicaArgs:
             pulumi.set(__self__, "date_created", date_created)
         if dbname is not None:
             pulumi.set(__self__, "dbname", dbname)
+        if eviction_policy is not None:
+            pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials is not None:
             pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         if host is not None:
@@ -341,8 +343,6 @@ class DatabaseReadReplicaArgs:
             pulumi.set(__self__, "port", port)
         if public_host is not None:
             pulumi.set(__self__, "public_host", public_host)
-        if redis_eviction_policy is not None:
-            pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if status is not None:
             pulumi.set(__self__, "status", status)
         if tag is not None:
@@ -437,6 +437,18 @@ class DatabaseReadReplicaArgs:
     @dbname.setter
     def dbname(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dbname", value)
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> Optional[pulumi.Input[str]]:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        """
+        return pulumi.get(self, "eviction_policy")
+
+    @eviction_policy.setter
+    def eviction_policy(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "eviction_policy", value)
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -655,18 +667,6 @@ class DatabaseReadReplicaArgs:
         pulumi.set(self, "public_host", value)
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> Optional[pulumi.Input[str]]:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @redis_eviction_policy.setter
-    def redis_eviction_policy(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "redis_eviction_policy", value)
-
-    @property
     @pulumi.getter
     def status(self) -> Optional[pulumi.Input[str]]:
         """
@@ -729,21 +729,21 @@ class DatabaseReadReplicaArgs:
 
 if not MYPY:
     class DatabaseUserAccessControlArgsDict(TypedDict):
-        redis_acl_categories: pulumi.Input[Sequence[pulumi.Input[str]]]
+        acl_categories: pulumi.Input[Sequence[pulumi.Input[str]]]
         """
-        The list of command category rules for this managed database user.
+        List of command category rules for this managed database user (Redis engine types only).
         """
-        redis_acl_channels: pulumi.Input[Sequence[pulumi.Input[str]]]
+        acl_channels: pulumi.Input[Sequence[pulumi.Input[str]]]
         """
-        The list of publish/subscribe channel patterns for this managed database user.
+        List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
         """
-        redis_acl_commands: pulumi.Input[Sequence[pulumi.Input[str]]]
+        acl_commands: pulumi.Input[Sequence[pulumi.Input[str]]]
         """
-        The list of individual command rules for this managed database user.
+        List of individual command rules for this managed database user (Redis engine types only).
         """
-        redis_acl_keys: pulumi.Input[Sequence[pulumi.Input[str]]]
+        acl_keys: pulumi.Input[Sequence[pulumi.Input[str]]]
         """
-        The list of access rules for this managed database user.
+        List of access rules for this managed database user (Redis engine types only).
         """
 elif False:
     DatabaseUserAccessControlArgsDict: TypeAlias = Mapping[str, Any]
@@ -751,68 +751,68 @@ elif False:
 @pulumi.input_type
 class DatabaseUserAccessControlArgs:
     def __init__(__self__, *,
-                 redis_acl_categories: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 redis_acl_channels: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 redis_acl_commands: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 redis_acl_keys: pulumi.Input[Sequence[pulumi.Input[str]]]):
+                 acl_categories: pulumi.Input[Sequence[pulumi.Input[str]]],
+                 acl_channels: pulumi.Input[Sequence[pulumi.Input[str]]],
+                 acl_commands: pulumi.Input[Sequence[pulumi.Input[str]]],
+                 acl_keys: pulumi.Input[Sequence[pulumi.Input[str]]]):
         """
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] redis_acl_categories: The list of command category rules for this managed database user.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] redis_acl_channels: The list of publish/subscribe channel patterns for this managed database user.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] redis_acl_commands: The list of individual command rules for this managed database user.
-        :param pulumi.Input[Sequence[pulumi.Input[str]]] redis_acl_keys: The list of access rules for this managed database user.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] acl_categories: List of command category rules for this managed database user (Redis engine types only).
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] acl_channels: List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] acl_commands: List of individual command rules for this managed database user (Redis engine types only).
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] acl_keys: List of access rules for this managed database user (Redis engine types only).
         """
-        pulumi.set(__self__, "redis_acl_categories", redis_acl_categories)
-        pulumi.set(__self__, "redis_acl_channels", redis_acl_channels)
-        pulumi.set(__self__, "redis_acl_commands", redis_acl_commands)
-        pulumi.set(__self__, "redis_acl_keys", redis_acl_keys)
+        pulumi.set(__self__, "acl_categories", acl_categories)
+        pulumi.set(__self__, "acl_channels", acl_channels)
+        pulumi.set(__self__, "acl_commands", acl_commands)
+        pulumi.set(__self__, "acl_keys", acl_keys)
 
     @property
-    @pulumi.getter(name="redisAclCategories")
-    def redis_acl_categories(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
+    @pulumi.getter(name="aclCategories")
+    def acl_categories(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
         """
-        The list of command category rules for this managed database user.
+        List of command category rules for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_categories")
+        return pulumi.get(self, "acl_categories")
 
-    @redis_acl_categories.setter
-    def redis_acl_categories(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
-        pulumi.set(self, "redis_acl_categories", value)
-
-    @property
-    @pulumi.getter(name="redisAclChannels")
-    def redis_acl_channels(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
-        """
-        The list of publish/subscribe channel patterns for this managed database user.
-        """
-        return pulumi.get(self, "redis_acl_channels")
-
-    @redis_acl_channels.setter
-    def redis_acl_channels(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
-        pulumi.set(self, "redis_acl_channels", value)
+    @acl_categories.setter
+    def acl_categories(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
+        pulumi.set(self, "acl_categories", value)
 
     @property
-    @pulumi.getter(name="redisAclCommands")
-    def redis_acl_commands(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
+    @pulumi.getter(name="aclChannels")
+    def acl_channels(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
         """
-        The list of individual command rules for this managed database user.
+        List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_commands")
+        return pulumi.get(self, "acl_channels")
 
-    @redis_acl_commands.setter
-    def redis_acl_commands(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
-        pulumi.set(self, "redis_acl_commands", value)
+    @acl_channels.setter
+    def acl_channels(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
+        pulumi.set(self, "acl_channels", value)
 
     @property
-    @pulumi.getter(name="redisAclKeys")
-    def redis_acl_keys(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
+    @pulumi.getter(name="aclCommands")
+    def acl_commands(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
         """
-        The list of access rules for this managed database user.
+        List of individual command rules for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_keys")
+        return pulumi.get(self, "acl_commands")
 
-    @redis_acl_keys.setter
-    def redis_acl_keys(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
-        pulumi.set(self, "redis_acl_keys", value)
+    @acl_commands.setter
+    def acl_commands(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
+        pulumi.set(self, "acl_commands", value)
+
+    @property
+    @pulumi.getter(name="aclKeys")
+    def acl_keys(self) -> pulumi.Input[Sequence[pulumi.Input[str]]]:
+        """
+        List of access rules for this managed database user (Redis engine types only).
+        """
+        return pulumi.get(self, "acl_keys")
+
+    @acl_keys.setter
+    def acl_keys(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
+        pulumi.set(self, "acl_keys", value)
 
 
 if not MYPY:

--- a/sdk/python/ediri_vultr/database.py
+++ b/sdk/python/ediri_vultr/database.py
@@ -29,6 +29,7 @@ class DatabaseArgs:
                  access_cert: Optional[pulumi.Input[str]] = None,
                  access_key: Optional[pulumi.Input[str]] = None,
                  cluster_time_zone: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  maintenance_dow: Optional[pulumi.Input[str]] = None,
                  maintenance_time: Optional[pulumi.Input[str]] = None,
@@ -42,7 +43,6 @@ class DatabaseArgs:
                  plan_replicas: Optional[pulumi.Input[int]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
                  read_replicas: Optional[pulumi.Input[Sequence[pulumi.Input['DatabaseReadReplicaArgs']]]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  sasl_port: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
                  trusted_ips: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -57,6 +57,7 @@ class DatabaseArgs:
         :param pulumi.Input[str] access_cert: The certificate to authenticate the default user (Kafka engine types only).
         :param pulumi.Input[str] access_key: The private key to authenticate the default user (Kafka engine types only).
         :param pulumi.Input[str] cluster_time_zone: The configured time zone for the Managed Database in TZ database format (e.g. `UTC`, `America/New_York`, `Europe/London`).
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] maintenance_dow: The preferred maintenance day of week for the managed database.
         :param pulumi.Input[str] maintenance_time: The preferred maintenance time for the managed database in 24-hour HH:00 format (e.g. `01:00`, `13:00`, `23:00`).
@@ -70,7 +71,6 @@ class DatabaseArgs:
         :param pulumi.Input[int] plan_replicas: The number of standby nodes available on the managed database (excluded for Kafka engine types).
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database (VPC-attached only).
         :param pulumi.Input[Sequence[pulumi.Input['DatabaseReadReplicaArgs']]] read_replicas: A list of read replicas attached to the managed database.
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[str] sasl_port: The SASL connection port for the managed database (Kafka engine types only).
         :param pulumi.Input[str] tag: The tag to assign to the managed database.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] trusted_ips: A list of allowed IP addresses for the managed database.
@@ -87,6 +87,8 @@ class DatabaseArgs:
             pulumi.set(__self__, "access_key", access_key)
         if cluster_time_zone is not None:
             pulumi.set(__self__, "cluster_time_zone", cluster_time_zone)
+        if eviction_policy is not None:
+            pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials is not None:
             pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         if maintenance_dow is not None:
@@ -113,8 +115,6 @@ class DatabaseArgs:
             pulumi.set(__self__, "public_host", public_host)
         if read_replicas is not None:
             pulumi.set(__self__, "read_replicas", read_replicas)
-        if redis_eviction_policy is not None:
-            pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if sasl_port is not None:
             pulumi.set(__self__, "sasl_port", sasl_port)
         if tag is not None:
@@ -219,6 +219,18 @@ class DatabaseArgs:
     @cluster_time_zone.setter
     def cluster_time_zone(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "cluster_time_zone", value)
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> Optional[pulumi.Input[str]]:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        """
+        return pulumi.get(self, "eviction_policy")
+
+    @eviction_policy.setter
+    def eviction_policy(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "eviction_policy", value)
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -377,18 +389,6 @@ class DatabaseArgs:
         pulumi.set(self, "read_replicas", value)
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> Optional[pulumi.Input[str]]:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @redis_eviction_policy.setter
-    def redis_eviction_policy(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "redis_eviction_policy", value)
-
-    @property
     @pulumi.getter(name="saslPort")
     def sasl_port(self) -> Optional[pulumi.Input[str]]:
         """
@@ -447,6 +447,7 @@ class _DatabaseState:
                  database_engine_version: Optional[pulumi.Input[str]] = None,
                  date_created: Optional[pulumi.Input[str]] = None,
                  dbname: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  host: Optional[pulumi.Input[str]] = None,
                  label: Optional[pulumi.Input[str]] = None,
@@ -467,7 +468,6 @@ class _DatabaseState:
                  port: Optional[pulumi.Input[str]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
                  read_replicas: Optional[pulumi.Input[Sequence[pulumi.Input['DatabaseReadReplicaArgs']]]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  sasl_port: Optional[pulumi.Input[str]] = None,
                  status: Optional[pulumi.Input[str]] = None,
@@ -484,6 +484,7 @@ class _DatabaseState:
         :param pulumi.Input[str] database_engine_version: The database engine version of the new managed database.
         :param pulumi.Input[str] date_created: The date the managed database was added to your Vultr account.
         :param pulumi.Input[str] dbname: The managed database's default logical database.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] host: The hostname assigned to the managed database.
         :param pulumi.Input[str] label: A label for the managed database.
@@ -504,7 +505,6 @@ class _DatabaseState:
         :param pulumi.Input[str] port: The connection port for the managed database.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database (VPC-attached only).
         :param pulumi.Input[Sequence[pulumi.Input['DatabaseReadReplicaArgs']]] read_replicas: A list of read replicas attached to the managed database.
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[str] region: The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         :param pulumi.Input[str] sasl_port: The SASL connection port for the managed database (Kafka engine types only).
         :param pulumi.Input[str] status: The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -527,6 +527,8 @@ class _DatabaseState:
             pulumi.set(__self__, "date_created", date_created)
         if dbname is not None:
             pulumi.set(__self__, "dbname", dbname)
+        if eviction_policy is not None:
+            pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials is not None:
             pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         if host is not None:
@@ -567,8 +569,6 @@ class _DatabaseState:
             pulumi.set(__self__, "public_host", public_host)
         if read_replicas is not None:
             pulumi.set(__self__, "read_replicas", read_replicas)
-        if redis_eviction_policy is not None:
-            pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if region is not None:
             pulumi.set(__self__, "region", region)
         if sasl_port is not None:
@@ -667,6 +667,18 @@ class _DatabaseState:
     @dbname.setter
     def dbname(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dbname", value)
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> Optional[pulumi.Input[str]]:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        """
+        return pulumi.get(self, "eviction_policy")
+
+    @eviction_policy.setter
+    def eviction_policy(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "eviction_policy", value)
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -909,18 +921,6 @@ class _DatabaseState:
         pulumi.set(self, "read_replicas", value)
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> Optional[pulumi.Input[str]]:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @redis_eviction_policy.setter
-    def redis_eviction_policy(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "redis_eviction_policy", value)
-
-    @property
     @pulumi.getter
     def region(self) -> Optional[pulumi.Input[str]]:
         """
@@ -1015,6 +1015,7 @@ class Database(pulumi.CustomResource):
                  cluster_time_zone: Optional[pulumi.Input[str]] = None,
                  database_engine: Optional[pulumi.Input[str]] = None,
                  database_engine_version: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  label: Optional[pulumi.Input[str]] = None,
                  maintenance_dow: Optional[pulumi.Input[str]] = None,
@@ -1030,7 +1031,6 @@ class Database(pulumi.CustomResource):
                  plan_replicas: Optional[pulumi.Input[int]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
                  read_replicas: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DatabaseReadReplicaArgs', 'DatabaseReadReplicaArgsDict']]]]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  sasl_port: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
@@ -1089,6 +1089,7 @@ class Database(pulumi.CustomResource):
         :param pulumi.Input[str] cluster_time_zone: The configured time zone for the Managed Database in TZ database format (e.g. `UTC`, `America/New_York`, `Europe/London`).
         :param pulumi.Input[str] database_engine: The database engine of the new managed database.
         :param pulumi.Input[str] database_engine_version: The database engine version of the new managed database.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] label: A label for the managed database.
         :param pulumi.Input[str] maintenance_dow: The preferred maintenance day of week for the managed database.
@@ -1104,7 +1105,6 @@ class Database(pulumi.CustomResource):
         :param pulumi.Input[int] plan_replicas: The number of standby nodes available on the managed database (excluded for Kafka engine types).
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database (VPC-attached only).
         :param pulumi.Input[Sequence[pulumi.Input[Union['DatabaseReadReplicaArgs', 'DatabaseReadReplicaArgsDict']]]] read_replicas: A list of read replicas attached to the managed database.
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[str] region: The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         :param pulumi.Input[str] sasl_port: The SASL connection port for the managed database (Kafka engine types only).
         :param pulumi.Input[str] tag: The tag to assign to the managed database.
@@ -1182,6 +1182,7 @@ class Database(pulumi.CustomResource):
                  cluster_time_zone: Optional[pulumi.Input[str]] = None,
                  database_engine: Optional[pulumi.Input[str]] = None,
                  database_engine_version: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  label: Optional[pulumi.Input[str]] = None,
                  maintenance_dow: Optional[pulumi.Input[str]] = None,
@@ -1197,7 +1198,6 @@ class Database(pulumi.CustomResource):
                  plan_replicas: Optional[pulumi.Input[int]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
                  read_replicas: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DatabaseReadReplicaArgs', 'DatabaseReadReplicaArgsDict']]]]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  sasl_port: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
@@ -1221,6 +1221,7 @@ class Database(pulumi.CustomResource):
             if database_engine_version is None and not opts.urn:
                 raise TypeError("Missing required property 'database_engine_version'")
             __props__.__dict__["database_engine_version"] = database_engine_version
+            __props__.__dict__["eviction_policy"] = eviction_policy
             __props__.__dict__["ferretdb_credentials"] = ferretdb_credentials
             if label is None and not opts.urn:
                 raise TypeError("Missing required property 'label'")
@@ -1240,7 +1241,6 @@ class Database(pulumi.CustomResource):
             __props__.__dict__["plan_replicas"] = plan_replicas
             __props__.__dict__["public_host"] = public_host
             __props__.__dict__["read_replicas"] = read_replicas
-            __props__.__dict__["redis_eviction_policy"] = redis_eviction_policy
             if region is None and not opts.urn:
                 raise TypeError("Missing required property 'region'")
             __props__.__dict__["region"] = region
@@ -1274,6 +1274,7 @@ class Database(pulumi.CustomResource):
             database_engine_version: Optional[pulumi.Input[str]] = None,
             date_created: Optional[pulumi.Input[str]] = None,
             dbname: Optional[pulumi.Input[str]] = None,
+            eviction_policy: Optional[pulumi.Input[str]] = None,
             ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
             host: Optional[pulumi.Input[str]] = None,
             label: Optional[pulumi.Input[str]] = None,
@@ -1294,7 +1295,6 @@ class Database(pulumi.CustomResource):
             port: Optional[pulumi.Input[str]] = None,
             public_host: Optional[pulumi.Input[str]] = None,
             read_replicas: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DatabaseReadReplicaArgs', 'DatabaseReadReplicaArgsDict']]]]] = None,
-            redis_eviction_policy: Optional[pulumi.Input[str]] = None,
             region: Optional[pulumi.Input[str]] = None,
             sasl_port: Optional[pulumi.Input[str]] = None,
             status: Optional[pulumi.Input[str]] = None,
@@ -1316,6 +1316,7 @@ class Database(pulumi.CustomResource):
         :param pulumi.Input[str] database_engine_version: The database engine version of the new managed database.
         :param pulumi.Input[str] date_created: The date the managed database was added to your Vultr account.
         :param pulumi.Input[str] dbname: The managed database's default logical database.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] host: The hostname assigned to the managed database.
         :param pulumi.Input[str] label: A label for the managed database.
@@ -1336,7 +1337,6 @@ class Database(pulumi.CustomResource):
         :param pulumi.Input[str] port: The connection port for the managed database.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database (VPC-attached only).
         :param pulumi.Input[Sequence[pulumi.Input[Union['DatabaseReadReplicaArgs', 'DatabaseReadReplicaArgsDict']]]] read_replicas: A list of read replicas attached to the managed database.
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param pulumi.Input[str] region: The ID of the region that the managed database is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         :param pulumi.Input[str] sasl_port: The SASL connection port for the managed database (Kafka engine types only).
         :param pulumi.Input[str] status: The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
@@ -1356,6 +1356,7 @@ class Database(pulumi.CustomResource):
         __props__.__dict__["database_engine_version"] = database_engine_version
         __props__.__dict__["date_created"] = date_created
         __props__.__dict__["dbname"] = dbname
+        __props__.__dict__["eviction_policy"] = eviction_policy
         __props__.__dict__["ferretdb_credentials"] = ferretdb_credentials
         __props__.__dict__["host"] = host
         __props__.__dict__["label"] = label
@@ -1376,7 +1377,6 @@ class Database(pulumi.CustomResource):
         __props__.__dict__["port"] = port
         __props__.__dict__["public_host"] = public_host
         __props__.__dict__["read_replicas"] = read_replicas
-        __props__.__dict__["redis_eviction_policy"] = redis_eviction_policy
         __props__.__dict__["region"] = region
         __props__.__dict__["sasl_port"] = sasl_port
         __props__.__dict__["status"] = status
@@ -1441,6 +1441,14 @@ class Database(pulumi.CustomResource):
         The managed database's default logical database.
         """
         return pulumi.get(self, "dbname")
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> pulumi.Output[str]:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        """
+        return pulumi.get(self, "eviction_policy")
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -1601,14 +1609,6 @@ class Database(pulumi.CustomResource):
         A list of read replicas attached to the managed database.
         """
         return pulumi.get(self, "read_replicas")
-
-    @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> pulumi.Output[str]:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
 
     @property
     @pulumi.getter

--- a/sdk/python/ediri_vultr/database_replica.py
+++ b/sdk/python/ediri_vultr/database_replica.py
@@ -22,6 +22,7 @@ class DatabaseReplicaArgs:
                  database_id: pulumi.Input[str],
                  label: pulumi.Input[str],
                  region: pulumi.Input[str],
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  mysql_long_query_time: Optional[pulumi.Input[int]] = None,
                  mysql_require_primary_key: Optional[pulumi.Input[bool]] = None,
@@ -29,7 +30,6 @@ class DatabaseReplicaArgs:
                  mysql_sql_modes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  plan_disk: Optional[pulumi.Input[int]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
                  trusted_ips: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
@@ -37,6 +37,7 @@ class DatabaseReplicaArgs:
         :param pulumi.Input[str] database_id: The managed database ID you want to attach this replica to.
         :param pulumi.Input[str] label: A label for the managed database read replica.
         :param pulumi.Input[str] region: The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[int] mysql_long_query_time: The configuration value for the long query time (in seconds) on the managed database read replica (MySQL engine types only).
         :param pulumi.Input[bool] mysql_require_primary_key: The configuration value for whether primary keys are required on the managed database read replica (MySQL engine types only).
@@ -44,13 +45,14 @@ class DatabaseReplicaArgs:
         :param pulumi.Input[Sequence[pulumi.Input[str]]] mysql_sql_modes: A list of SQL modes currently configured for the managed database read replica (MySQL engine types only).
         :param pulumi.Input[int] plan_disk: The description of the disk(s) on the managed database read replica.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database read replica (VPC-attached only).
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[str] tag: The tag to assign to the managed database read replica.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] trusted_ips: A list of allowed IP addresses for the managed database read replica.
         """
         pulumi.set(__self__, "database_id", database_id)
         pulumi.set(__self__, "label", label)
         pulumi.set(__self__, "region", region)
+        if eviction_policy is not None:
+            pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials is not None:
             pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         if mysql_long_query_time is not None:
@@ -65,8 +67,6 @@ class DatabaseReplicaArgs:
             pulumi.set(__self__, "plan_disk", plan_disk)
         if public_host is not None:
             pulumi.set(__self__, "public_host", public_host)
-        if redis_eviction_policy is not None:
-            pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if tag is not None:
             pulumi.set(__self__, "tag", tag)
         if trusted_ips is not None:
@@ -107,6 +107,18 @@ class DatabaseReplicaArgs:
     @region.setter
     def region(self, value: pulumi.Input[str]):
         pulumi.set(self, "region", value)
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> Optional[pulumi.Input[str]]:
+        """
+        The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+        """
+        return pulumi.get(self, "eviction_policy")
+
+    @eviction_policy.setter
+    def eviction_policy(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "eviction_policy", value)
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -193,18 +205,6 @@ class DatabaseReplicaArgs:
         pulumi.set(self, "public_host", value)
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> Optional[pulumi.Input[str]]:
-        """
-        The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @redis_eviction_policy.setter
-    def redis_eviction_policy(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "redis_eviction_policy", value)
-
-    @property
     @pulumi.getter
     def tag(self) -> Optional[pulumi.Input[str]]:
         """
@@ -238,6 +238,7 @@ class _DatabaseReplicaState:
                  database_id: Optional[pulumi.Input[str]] = None,
                  date_created: Optional[pulumi.Input[str]] = None,
                  dbname: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  host: Optional[pulumi.Input[str]] = None,
                  label: Optional[pulumi.Input[str]] = None,
@@ -256,7 +257,6 @@ class _DatabaseReplicaState:
                  plan_vcpus: Optional[pulumi.Input[int]] = None,
                  port: Optional[pulumi.Input[str]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  status: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
@@ -271,6 +271,7 @@ class _DatabaseReplicaState:
         :param pulumi.Input[str] database_id: The managed database ID you want to attach this replica to.
         :param pulumi.Input[str] date_created: The date the managed database read replica was added to your Vultr account.
         :param pulumi.Input[str] dbname: The managed database read replica's default logical database.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] host: The hostname assigned to the managed database read replica.
         :param pulumi.Input[str] label: A label for the managed database read replica.
@@ -289,7 +290,6 @@ class _DatabaseReplicaState:
         :param pulumi.Input[int] plan_vcpus: The number of virtual CPUs available on the managed database read replica.
         :param pulumi.Input[str] port: The connection port for the managed database read replica.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database read replica (VPC-attached only).
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[str] region: The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         :param pulumi.Input[str] status: The current status of the managed database read replica (poweroff, rebuilding, rebalancing, configuring, running).
         :param pulumi.Input[str] tag: The tag to assign to the managed database read replica.
@@ -309,6 +309,8 @@ class _DatabaseReplicaState:
             pulumi.set(__self__, "date_created", date_created)
         if dbname is not None:
             pulumi.set(__self__, "dbname", dbname)
+        if eviction_policy is not None:
+            pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials is not None:
             pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         if host is not None:
@@ -345,8 +347,6 @@ class _DatabaseReplicaState:
             pulumi.set(__self__, "port", port)
         if public_host is not None:
             pulumi.set(__self__, "public_host", public_host)
-        if redis_eviction_policy is not None:
-            pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if region is not None:
             pulumi.set(__self__, "region", region)
         if status is not None:
@@ -431,6 +431,18 @@ class _DatabaseReplicaState:
     @dbname.setter
     def dbname(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dbname", value)
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> Optional[pulumi.Input[str]]:
+        """
+        The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+        """
+        return pulumi.get(self, "eviction_policy")
+
+    @eviction_policy.setter
+    def eviction_policy(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "eviction_policy", value)
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -649,18 +661,6 @@ class _DatabaseReplicaState:
         pulumi.set(self, "public_host", value)
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> Optional[pulumi.Input[str]]:
-        """
-        The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @redis_eviction_policy.setter
-    def redis_eviction_policy(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "redis_eviction_policy", value)
-
-    @property
     @pulumi.getter
     def region(self) -> Optional[pulumi.Input[str]]:
         """
@@ -739,6 +739,7 @@ class DatabaseReplica(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  database_id: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  label: Optional[pulumi.Input[str]] = None,
                  mysql_long_query_time: Optional[pulumi.Input[int]] = None,
@@ -747,7 +748,6 @@ class DatabaseReplica(pulumi.CustomResource):
                  mysql_sql_modes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  plan_disk: Optional[pulumi.Input[int]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
                  trusted_ips: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -773,6 +773,7 @@ class DatabaseReplica(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] database_id: The managed database ID you want to attach this replica to.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] label: A label for the managed database read replica.
         :param pulumi.Input[int] mysql_long_query_time: The configuration value for the long query time (in seconds) on the managed database read replica (MySQL engine types only).
@@ -781,7 +782,6 @@ class DatabaseReplica(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] mysql_sql_modes: A list of SQL modes currently configured for the managed database read replica (MySQL engine types only).
         :param pulumi.Input[int] plan_disk: The description of the disk(s) on the managed database read replica.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database read replica (VPC-attached only).
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[str] region: The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         :param pulumi.Input[str] tag: The tag to assign to the managed database read replica.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] trusted_ips: A list of allowed IP addresses for the managed database read replica.
@@ -826,6 +826,7 @@ class DatabaseReplica(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  database_id: Optional[pulumi.Input[str]] = None,
+                 eviction_policy: Optional[pulumi.Input[str]] = None,
                  ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  label: Optional[pulumi.Input[str]] = None,
                  mysql_long_query_time: Optional[pulumi.Input[int]] = None,
@@ -834,7 +835,6 @@ class DatabaseReplica(pulumi.CustomResource):
                  mysql_sql_modes: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  plan_disk: Optional[pulumi.Input[int]] = None,
                  public_host: Optional[pulumi.Input[str]] = None,
-                 redis_eviction_policy: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  tag: Optional[pulumi.Input[str]] = None,
                  trusted_ips: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -850,6 +850,7 @@ class DatabaseReplica(pulumi.CustomResource):
             if database_id is None and not opts.urn:
                 raise TypeError("Missing required property 'database_id'")
             __props__.__dict__["database_id"] = database_id
+            __props__.__dict__["eviction_policy"] = eviction_policy
             __props__.__dict__["ferretdb_credentials"] = ferretdb_credentials
             if label is None and not opts.urn:
                 raise TypeError("Missing required property 'label'")
@@ -860,7 +861,6 @@ class DatabaseReplica(pulumi.CustomResource):
             __props__.__dict__["mysql_sql_modes"] = mysql_sql_modes
             __props__.__dict__["plan_disk"] = plan_disk
             __props__.__dict__["public_host"] = public_host
-            __props__.__dict__["redis_eviction_policy"] = redis_eviction_policy
             if region is None and not opts.urn:
                 raise TypeError("Missing required property 'region'")
             __props__.__dict__["region"] = region
@@ -900,6 +900,7 @@ class DatabaseReplica(pulumi.CustomResource):
             database_id: Optional[pulumi.Input[str]] = None,
             date_created: Optional[pulumi.Input[str]] = None,
             dbname: Optional[pulumi.Input[str]] = None,
+            eviction_policy: Optional[pulumi.Input[str]] = None,
             ferretdb_credentials: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
             host: Optional[pulumi.Input[str]] = None,
             label: Optional[pulumi.Input[str]] = None,
@@ -918,7 +919,6 @@ class DatabaseReplica(pulumi.CustomResource):
             plan_vcpus: Optional[pulumi.Input[int]] = None,
             port: Optional[pulumi.Input[str]] = None,
             public_host: Optional[pulumi.Input[str]] = None,
-            redis_eviction_policy: Optional[pulumi.Input[str]] = None,
             region: Optional[pulumi.Input[str]] = None,
             status: Optional[pulumi.Input[str]] = None,
             tag: Optional[pulumi.Input[str]] = None,
@@ -938,6 +938,7 @@ class DatabaseReplica(pulumi.CustomResource):
         :param pulumi.Input[str] database_id: The managed database ID you want to attach this replica to.
         :param pulumi.Input[str] date_created: The date the managed database read replica was added to your Vultr account.
         :param pulumi.Input[str] dbname: The managed database read replica's default logical database.
+        :param pulumi.Input[str] eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param pulumi.Input[str] host: The hostname assigned to the managed database read replica.
         :param pulumi.Input[str] label: A label for the managed database read replica.
@@ -956,7 +957,6 @@ class DatabaseReplica(pulumi.CustomResource):
         :param pulumi.Input[int] plan_vcpus: The number of virtual CPUs available on the managed database read replica.
         :param pulumi.Input[str] port: The connection port for the managed database read replica.
         :param pulumi.Input[str] public_host: The public hostname assigned to the managed database read replica (VPC-attached only).
-        :param pulumi.Input[str] redis_eviction_policy: The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
         :param pulumi.Input[str] region: The ID of the region that the managed database read replica is to be created in. [See List Regions](https://www.vultr.com/api/#operation/list-regions)
         :param pulumi.Input[str] status: The current status of the managed database read replica (poweroff, rebuilding, rebalancing, configuring, running).
         :param pulumi.Input[str] tag: The tag to assign to the managed database read replica.
@@ -974,6 +974,7 @@ class DatabaseReplica(pulumi.CustomResource):
         __props__.__dict__["database_id"] = database_id
         __props__.__dict__["date_created"] = date_created
         __props__.__dict__["dbname"] = dbname
+        __props__.__dict__["eviction_policy"] = eviction_policy
         __props__.__dict__["ferretdb_credentials"] = ferretdb_credentials
         __props__.__dict__["host"] = host
         __props__.__dict__["label"] = label
@@ -992,7 +993,6 @@ class DatabaseReplica(pulumi.CustomResource):
         __props__.__dict__["plan_vcpus"] = plan_vcpus
         __props__.__dict__["port"] = port
         __props__.__dict__["public_host"] = public_host
-        __props__.__dict__["redis_eviction_policy"] = redis_eviction_policy
         __props__.__dict__["region"] = region
         __props__.__dict__["status"] = status
         __props__.__dict__["tag"] = tag
@@ -1048,6 +1048,14 @@ class DatabaseReplica(pulumi.CustomResource):
         The managed database read replica's default logical database.
         """
         return pulumi.get(self, "dbname")
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> pulumi.Output[str]:
+        """
+        The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
+        """
+        return pulumi.get(self, "eviction_policy")
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -1192,14 +1200,6 @@ class DatabaseReplica(pulumi.CustomResource):
         The public hostname assigned to the managed database read replica (VPC-attached only).
         """
         return pulumi.get(self, "public_host")
-
-    @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> pulumi.Output[str]:
-        """
-        The configuration value for the data eviction policy on the managed database read replica (Redis engine types only).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
 
     @property
     @pulumi.getter

--- a/sdk/python/ediri_vultr/get_database.py
+++ b/sdk/python/ediri_vultr/get_database.py
@@ -28,7 +28,7 @@ class GetDatabaseResult:
     """
     A collection of values returned by getDatabase.
     """
-    def __init__(__self__, access_cert=None, access_key=None, cluster_time_zone=None, database_engine=None, database_engine_version=None, date_created=None, dbname=None, ferretdb_credentials=None, filters=None, host=None, id=None, label=None, latest_backup=None, maintenance_dow=None, maintenance_time=None, mysql_long_query_time=None, mysql_require_primary_key=None, mysql_slow_query_log=None, mysql_sql_modes=None, password=None, plan=None, plan_brokers=None, plan_disk=None, plan_ram=None, plan_replicas=None, plan_vcpus=None, port=None, public_host=None, read_replicas=None, redis_eviction_policy=None, region=None, sasl_port=None, status=None, tag=None, trusted_ips=None, user=None, vpc_id=None):
+    def __init__(__self__, access_cert=None, access_key=None, cluster_time_zone=None, database_engine=None, database_engine_version=None, date_created=None, dbname=None, eviction_policy=None, ferretdb_credentials=None, filters=None, host=None, id=None, label=None, latest_backup=None, maintenance_dow=None, maintenance_time=None, mysql_long_query_time=None, mysql_require_primary_key=None, mysql_slow_query_log=None, mysql_sql_modes=None, password=None, plan=None, plan_brokers=None, plan_disk=None, plan_ram=None, plan_replicas=None, plan_vcpus=None, port=None, public_host=None, read_replicas=None, region=None, sasl_port=None, status=None, tag=None, trusted_ips=None, user=None, vpc_id=None):
         if access_cert and not isinstance(access_cert, str):
             raise TypeError("Expected argument 'access_cert' to be a str")
         pulumi.set(__self__, "access_cert", access_cert)
@@ -50,6 +50,9 @@ class GetDatabaseResult:
         if dbname and not isinstance(dbname, str):
             raise TypeError("Expected argument 'dbname' to be a str")
         pulumi.set(__self__, "dbname", dbname)
+        if eviction_policy and not isinstance(eviction_policy, str):
+            raise TypeError("Expected argument 'eviction_policy' to be a str")
+        pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials and not isinstance(ferretdb_credentials, dict):
             raise TypeError("Expected argument 'ferretdb_credentials' to be a dict")
         pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
@@ -116,9 +119,6 @@ class GetDatabaseResult:
         if read_replicas and not isinstance(read_replicas, list):
             raise TypeError("Expected argument 'read_replicas' to be a list")
         pulumi.set(__self__, "read_replicas", read_replicas)
-        if redis_eviction_policy and not isinstance(redis_eviction_policy, str):
-            raise TypeError("Expected argument 'redis_eviction_policy' to be a str")
-        pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if region and not isinstance(region, str):
             raise TypeError("Expected argument 'region' to be a str")
         pulumi.set(__self__, "region", region)
@@ -196,6 +196,14 @@ class GetDatabaseResult:
         The managed database's default logical database.
         """
         return pulumi.get(self, "dbname")
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> str:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only).
+        """
+        return pulumi.get(self, "eviction_policy")
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -368,14 +376,6 @@ class GetDatabaseResult:
         return pulumi.get(self, "read_replicas")
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> str:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @property
     @pulumi.getter
     def region(self) -> str:
         """
@@ -445,6 +445,7 @@ class AwaitableGetDatabaseResult(GetDatabaseResult):
             database_engine_version=self.database_engine_version,
             date_created=self.date_created,
             dbname=self.dbname,
+            eviction_policy=self.eviction_policy,
             ferretdb_credentials=self.ferretdb_credentials,
             filters=self.filters,
             host=self.host,
@@ -467,7 +468,6 @@ class AwaitableGetDatabaseResult(GetDatabaseResult):
             port=self.port,
             public_host=self.public_host,
             read_replicas=self.read_replicas,
-            redis_eviction_policy=self.redis_eviction_policy,
             region=self.region,
             sasl_port=self.sasl_port,
             status=self.status,
@@ -512,6 +512,7 @@ def get_database(filters: Optional[Sequence[Union['GetDatabaseFilterArgs', 'GetD
         database_engine_version=pulumi.get(__ret__, 'database_engine_version'),
         date_created=pulumi.get(__ret__, 'date_created'),
         dbname=pulumi.get(__ret__, 'dbname'),
+        eviction_policy=pulumi.get(__ret__, 'eviction_policy'),
         ferretdb_credentials=pulumi.get(__ret__, 'ferretdb_credentials'),
         filters=pulumi.get(__ret__, 'filters'),
         host=pulumi.get(__ret__, 'host'),
@@ -534,7 +535,6 @@ def get_database(filters: Optional[Sequence[Union['GetDatabaseFilterArgs', 'GetD
         port=pulumi.get(__ret__, 'port'),
         public_host=pulumi.get(__ret__, 'public_host'),
         read_replicas=pulumi.get(__ret__, 'read_replicas'),
-        redis_eviction_policy=pulumi.get(__ret__, 'redis_eviction_policy'),
         region=pulumi.get(__ret__, 'region'),
         sasl_port=pulumi.get(__ret__, 'sasl_port'),
         status=pulumi.get(__ret__, 'status'),
@@ -576,6 +576,7 @@ def get_database_output(filters: Optional[pulumi.Input[Optional[Sequence[Union['
         database_engine_version=pulumi.get(__response__, 'database_engine_version'),
         date_created=pulumi.get(__response__, 'date_created'),
         dbname=pulumi.get(__response__, 'dbname'),
+        eviction_policy=pulumi.get(__response__, 'eviction_policy'),
         ferretdb_credentials=pulumi.get(__response__, 'ferretdb_credentials'),
         filters=pulumi.get(__response__, 'filters'),
         host=pulumi.get(__response__, 'host'),
@@ -598,7 +599,6 @@ def get_database_output(filters: Optional[pulumi.Input[Optional[Sequence[Union['
         port=pulumi.get(__response__, 'port'),
         public_host=pulumi.get(__response__, 'public_host'),
         read_replicas=pulumi.get(__response__, 'read_replicas'),
-        redis_eviction_policy=pulumi.get(__response__, 'redis_eviction_policy'),
         region=pulumi.get(__response__, 'region'),
         sasl_port=pulumi.get(__response__, 'sasl_port'),
         status=pulumi.get(__response__, 'status'),

--- a/sdk/python/ediri_vultr/outputs.py
+++ b/sdk/python/ediri_vultr/outputs.py
@@ -75,6 +75,8 @@ class DatabaseReadReplica(dict):
             suggest = "database_engine_version"
         elif key == "dateCreated":
             suggest = "date_created"
+        elif key == "evictionPolicy":
+            suggest = "eviction_policy"
         elif key == "ferretdbCredentials":
             suggest = "ferretdb_credentials"
         elif key == "latestBackup":
@@ -101,8 +103,6 @@ class DatabaseReadReplica(dict):
             suggest = "plan_vcpus"
         elif key == "publicHost":
             suggest = "public_host"
-        elif key == "redisEvictionPolicy":
-            suggest = "redis_eviction_policy"
         elif key == "trustedIps":
             suggest = "trusted_ips"
         elif key == "vpcId":
@@ -127,6 +127,7 @@ class DatabaseReadReplica(dict):
                  database_engine_version: Optional[str] = None,
                  date_created: Optional[str] = None,
                  dbname: Optional[str] = None,
+                 eviction_policy: Optional[str] = None,
                  ferretdb_credentials: Optional[Mapping[str, str]] = None,
                  host: Optional[str] = None,
                  id: Optional[str] = None,
@@ -145,7 +146,6 @@ class DatabaseReadReplica(dict):
                  plan_vcpus: Optional[int] = None,
                  port: Optional[str] = None,
                  public_host: Optional[str] = None,
-                 redis_eviction_policy: Optional[str] = None,
                  status: Optional[str] = None,
                  tag: Optional[str] = None,
                  trusted_ips: Optional[Sequence[str]] = None,
@@ -159,6 +159,7 @@ class DatabaseReadReplica(dict):
         :param str database_engine_version: The database engine version of the new managed database.
         :param str date_created: The date the managed database was added to your Vultr account.
         :param str dbname: The managed database's default logical database.
+        :param str eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param Mapping[str, str] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param str host: The hostname assigned to the managed database.
         :param str id: The ID of the managed database.
@@ -177,7 +178,6 @@ class DatabaseReadReplica(dict):
         :param int plan_vcpus: The number of virtual CPUs available on the managed database.
         :param str port: The connection port for the managed database.
         :param str public_host: The public hostname assigned to the managed database (VPC-attached only).
-        :param str redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
         :param str status: The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
         :param str tag: The tag to assign to the managed database.
         :param Sequence[str] trusted_ips: A list of allowed IP addresses for the managed database.
@@ -196,6 +196,8 @@ class DatabaseReadReplica(dict):
             pulumi.set(__self__, "date_created", date_created)
         if dbname is not None:
             pulumi.set(__self__, "dbname", dbname)
+        if eviction_policy is not None:
+            pulumi.set(__self__, "eviction_policy", eviction_policy)
         if ferretdb_credentials is not None:
             pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         if host is not None:
@@ -232,8 +234,6 @@ class DatabaseReadReplica(dict):
             pulumi.set(__self__, "port", port)
         if public_host is not None:
             pulumi.set(__self__, "public_host", public_host)
-        if redis_eviction_policy is not None:
-            pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         if status is not None:
             pulumi.set(__self__, "status", status)
         if tag is not None:
@@ -300,6 +300,14 @@ class DatabaseReadReplica(dict):
         The managed database's default logical database.
         """
         return pulumi.get(self, "dbname")
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> Optional[str]:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
+        """
+        return pulumi.get(self, "eviction_policy")
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -446,14 +454,6 @@ class DatabaseReadReplica(dict):
         return pulumi.get(self, "public_host")
 
     @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> Optional[str]:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only - `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`, `volatile-random`, `volatile-ttl`, `volatile-lfu`, `allkeys-lfu`).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
-
-    @property
     @pulumi.getter
     def status(self) -> Optional[str]:
         """
@@ -499,14 +499,14 @@ class DatabaseUserAccessControl(dict):
     @staticmethod
     def __key_warning(key: str):
         suggest = None
-        if key == "redisAclCategories":
-            suggest = "redis_acl_categories"
-        elif key == "redisAclChannels":
-            suggest = "redis_acl_channels"
-        elif key == "redisAclCommands":
-            suggest = "redis_acl_commands"
-        elif key == "redisAclKeys":
-            suggest = "redis_acl_keys"
+        if key == "aclCategories":
+            suggest = "acl_categories"
+        elif key == "aclChannels":
+            suggest = "acl_channels"
+        elif key == "aclCommands":
+            suggest = "acl_commands"
+        elif key == "aclKeys":
+            suggest = "acl_keys"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in DatabaseUserAccessControl. Access the value via the '{suggest}' property getter instead.")
@@ -520,52 +520,52 @@ class DatabaseUserAccessControl(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 redis_acl_categories: Sequence[str],
-                 redis_acl_channels: Sequence[str],
-                 redis_acl_commands: Sequence[str],
-                 redis_acl_keys: Sequence[str]):
+                 acl_categories: Sequence[str],
+                 acl_channels: Sequence[str],
+                 acl_commands: Sequence[str],
+                 acl_keys: Sequence[str]):
         """
-        :param Sequence[str] redis_acl_categories: The list of command category rules for this managed database user.
-        :param Sequence[str] redis_acl_channels: The list of publish/subscribe channel patterns for this managed database user.
-        :param Sequence[str] redis_acl_commands: The list of individual command rules for this managed database user.
-        :param Sequence[str] redis_acl_keys: The list of access rules for this managed database user.
+        :param Sequence[str] acl_categories: List of command category rules for this managed database user (Redis engine types only).
+        :param Sequence[str] acl_channels: List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
+        :param Sequence[str] acl_commands: List of individual command rules for this managed database user (Redis engine types only).
+        :param Sequence[str] acl_keys: List of access rules for this managed database user (Redis engine types only).
         """
-        pulumi.set(__self__, "redis_acl_categories", redis_acl_categories)
-        pulumi.set(__self__, "redis_acl_channels", redis_acl_channels)
-        pulumi.set(__self__, "redis_acl_commands", redis_acl_commands)
-        pulumi.set(__self__, "redis_acl_keys", redis_acl_keys)
+        pulumi.set(__self__, "acl_categories", acl_categories)
+        pulumi.set(__self__, "acl_channels", acl_channels)
+        pulumi.set(__self__, "acl_commands", acl_commands)
+        pulumi.set(__self__, "acl_keys", acl_keys)
 
     @property
-    @pulumi.getter(name="redisAclCategories")
-    def redis_acl_categories(self) -> Sequence[str]:
+    @pulumi.getter(name="aclCategories")
+    def acl_categories(self) -> Sequence[str]:
         """
-        The list of command category rules for this managed database user.
+        List of command category rules for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_categories")
+        return pulumi.get(self, "acl_categories")
 
     @property
-    @pulumi.getter(name="redisAclChannels")
-    def redis_acl_channels(self) -> Sequence[str]:
+    @pulumi.getter(name="aclChannels")
+    def acl_channels(self) -> Sequence[str]:
         """
-        The list of publish/subscribe channel patterns for this managed database user.
+        List of publish/subscribe channel patterns for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_channels")
+        return pulumi.get(self, "acl_channels")
 
     @property
-    @pulumi.getter(name="redisAclCommands")
-    def redis_acl_commands(self) -> Sequence[str]:
+    @pulumi.getter(name="aclCommands")
+    def acl_commands(self) -> Sequence[str]:
         """
-        The list of individual command rules for this managed database user.
+        List of individual command rules for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_commands")
+        return pulumi.get(self, "acl_commands")
 
     @property
-    @pulumi.getter(name="redisAclKeys")
-    def redis_acl_keys(self) -> Sequence[str]:
+    @pulumi.getter(name="aclKeys")
+    def acl_keys(self) -> Sequence[str]:
         """
-        The list of access rules for this managed database user.
+        List of access rules for this managed database user (Redis engine types only).
         """
-        return pulumi.get(self, "redis_acl_keys")
+        return pulumi.get(self, "acl_keys")
 
 
 @pulumi.output_type
@@ -1487,6 +1487,7 @@ class GetDatabaseReadReplicaResult(dict):
                  database_engine_version: str,
                  date_created: str,
                  dbname: str,
+                 eviction_policy: str,
                  ferretdb_credentials: Mapping[str, str],
                  host: str,
                  id: str,
@@ -1506,7 +1507,6 @@ class GetDatabaseReadReplicaResult(dict):
                  plan_vcpus: int,
                  port: str,
                  public_host: str,
-                 redis_eviction_policy: str,
                  region: str,
                  status: str,
                  tag: str,
@@ -1519,6 +1519,7 @@ class GetDatabaseReadReplicaResult(dict):
         :param str database_engine_version: The database engine version of the managed database.
         :param str date_created: The date the managed database was added to your Vultr account.
         :param str dbname: The managed database's default logical database.
+        :param str eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only).
         :param Mapping[str, str] ferretdb_credentials: An associated list of FerretDB connection credentials (FerretDB + PostgreSQL engine types only).
         :param str host: The hostname assigned to the managed database.
         :param str label: The managed database's label.
@@ -1537,7 +1538,6 @@ class GetDatabaseReadReplicaResult(dict):
         :param int plan_vcpus: The number of virtual CPUs available on the managed database.
         :param str port: The connection port for the managed database.
         :param str public_host: The public hostname assigned to the managed database (VPC-attached only).
-        :param str redis_eviction_policy: The configuration value for the data eviction policy on the managed database (Redis engine types only).
         :param str region: The region ID of the managed database.
         :param str status: The current status of the managed database (poweroff, rebuilding, rebalancing, configuring, running).
         :param str tag: The managed database's tag.
@@ -1550,6 +1550,7 @@ class GetDatabaseReadReplicaResult(dict):
         pulumi.set(__self__, "database_engine_version", database_engine_version)
         pulumi.set(__self__, "date_created", date_created)
         pulumi.set(__self__, "dbname", dbname)
+        pulumi.set(__self__, "eviction_policy", eviction_policy)
         pulumi.set(__self__, "ferretdb_credentials", ferretdb_credentials)
         pulumi.set(__self__, "host", host)
         pulumi.set(__self__, "id", id)
@@ -1569,7 +1570,6 @@ class GetDatabaseReadReplicaResult(dict):
         pulumi.set(__self__, "plan_vcpus", plan_vcpus)
         pulumi.set(__self__, "port", port)
         pulumi.set(__self__, "public_host", public_host)
-        pulumi.set(__self__, "redis_eviction_policy", redis_eviction_policy)
         pulumi.set(__self__, "region", region)
         pulumi.set(__self__, "status", status)
         pulumi.set(__self__, "tag", tag)
@@ -1616,6 +1616,14 @@ class GetDatabaseReadReplicaResult(dict):
         The managed database's default logical database.
         """
         return pulumi.get(self, "dbname")
+
+    @property
+    @pulumi.getter(name="evictionPolicy")
+    def eviction_policy(self) -> str:
+        """
+        The configuration value for the data eviction policy on the managed database (Redis engine types only).
+        """
+        return pulumi.get(self, "eviction_policy")
 
     @property
     @pulumi.getter(name="ferretdbCredentials")
@@ -1765,14 +1773,6 @@ class GetDatabaseReadReplicaResult(dict):
         The public hostname assigned to the managed database (VPC-attached only).
         """
         return pulumi.get(self, "public_host")
-
-    @property
-    @pulumi.getter(name="redisEvictionPolicy")
-    def redis_eviction_policy(self) -> str:
-        """
-        The configuration value for the data eviction policy on the managed database (Redis engine types only).
-        """
-        return pulumi.get(self, "redis_eviction_policy")
 
     @property
     @pulumi.getter

--- a/sdk/python/ediri_vultr/snapshot.py
+++ b/sdk/python/ediri_vultr/snapshot.py
@@ -25,6 +25,10 @@ class SnapshotArgs:
         The set of arguments for constructing a Snapshot resource.
         :param pulumi.Input[str] instance_id: ID of a given instance that you want to create a snapshot from.
         :param pulumi.Input[str] description: The description for the given snapshot.
+               
+               Snapshots often exceed the default timeout built in to all create requests in
+               the provider. In order to customize that, you may specify a custome value in a
+               `timeouts` block of the resource definition
         """
         pulumi.set(__self__, "instance_id", instance_id)
         if description is not None:
@@ -47,6 +51,10 @@ class SnapshotArgs:
     def description(self) -> Optional[pulumi.Input[str]]:
         """
         The description for the given snapshot.
+
+        Snapshots often exceed the default timeout built in to all create requests in
+        the provider. In order to customize that, you may specify a custome value in a
+        `timeouts` block of the resource definition
         """
         return pulumi.get(self, "description")
 
@@ -70,6 +78,10 @@ class _SnapshotState:
         :param pulumi.Input[int] app_id: The app id which the snapshot is associated with.
         :param pulumi.Input[str] date_created: The date the snapshot was created.
         :param pulumi.Input[str] description: The description for the given snapshot.
+               
+               Snapshots often exceed the default timeout built in to all create requests in
+               the provider. In order to customize that, you may specify a custome value in a
+               `timeouts` block of the resource definition
         :param pulumi.Input[str] instance_id: ID of a given instance that you want to create a snapshot from.
         :param pulumi.Input[int] os_id: The os id which the snapshot is associated with.
         :param pulumi.Input[int] size: The size of the snapshot in Bytes.
@@ -119,6 +131,10 @@ class _SnapshotState:
     def description(self) -> Optional[pulumi.Input[str]]:
         """
         The description for the given snapshot.
+
+        Snapshots often exceed the default timeout built in to all create requests in
+        the provider. In order to customize that, you may specify a custome value in a
+        `timeouts` block of the resource definition
         """
         return pulumi.get(self, "description")
 
@@ -215,6 +231,10 @@ class Snapshot(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description: The description for the given snapshot.
+               
+               Snapshots often exceed the default timeout built in to all create requests in
+               the provider. In order to customize that, you may specify a custome value in a
+               `timeouts` block of the resource definition
         :param pulumi.Input[str] instance_id: ID of a given instance that you want to create a snapshot from.
         """
         ...
@@ -314,6 +334,10 @@ class Snapshot(pulumi.CustomResource):
         :param pulumi.Input[int] app_id: The app id which the snapshot is associated with.
         :param pulumi.Input[str] date_created: The date the snapshot was created.
         :param pulumi.Input[str] description: The description for the given snapshot.
+               
+               Snapshots often exceed the default timeout built in to all create requests in
+               the provider. In order to customize that, you may specify a custome value in a
+               `timeouts` block of the resource definition
         :param pulumi.Input[str] instance_id: ID of a given instance that you want to create a snapshot from.
         :param pulumi.Input[int] os_id: The os id which the snapshot is associated with.
         :param pulumi.Input[int] size: The size of the snapshot in Bytes.
@@ -353,6 +377,10 @@ class Snapshot(pulumi.CustomResource):
     def description(self) -> pulumi.Output[Optional[str]]:
         """
         The description for the given snapshot.
+
+        Snapshots often exceed the default timeout built in to all create requests in
+        the provider. In order to customize that, you may specify a custome value in a
+        `timeouts` block of the resource definition
         """
         return pulumi.get(self, "description")
 


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider dirien/pulumi-vultr --kind=all --target-bridge-version=latest`.

---

- Upgrading terraform-provider-vultr from 2.22.1  to 2.23.1.
