### PR TITLE
Added correct Vultr urn mapping for ContainerRegistry resource

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -117,8 +117,14 @@ func Provider() tfbridge.ProviderInfo {
 			// 		"tags": {Type: tfbridge.MakeType(mainPkg, "Tags")},
 			// 	},
 			// },
-			"vultr_bare_metal_server":        {Tok: tfbridge.MakeResource(mainPkg, mainMod, "BareMetalServer")},
-			"vultr_block_storage":            {Tok: tfbridge.MakeResource(mainPkg, mainMod, "BlockStorage")},
+			"vultr_bare_metal_server": {Tok: tfbridge.MakeResource(mainPkg, mainMod, "BareMetalServer")},
+			"vultr_block_storage":     {Tok: tfbridge.MakeResource(mainPkg, mainMod, "BlockStorage")},
+			"vultr_container_registry": {
+				Tok: tfbridge.MakeResource(mainPkg, mainMod, "ContainerRegistry"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"urn": {Name: "containerRegistryURN"},
+				},
+			},
 			"vultr_dns_domain":               {Tok: tfbridge.MakeResource(mainPkg, mainMod, "DnsDomain")},
 			"vultr_dns_record":               {Tok: tfbridge.MakeResource(mainPkg, mainMod, "DnsRecord")},
 			"vultr_firewall_group":           {Tok: tfbridge.MakeResource(mainPkg, mainMod, "FirewallGroup")},


### PR DESCRIPTION
URN is a reserved keyword in Pulumi and package codegenerators override it with Pulumi's one making it inaccessible (or they crash as the codegen for Scala SDK for Pulumi and that's how I came to know about this issue). Added a mapping for the Vultr's ContainerRegistry `urn` field to `containerRegistryURN`. This new name is how Pulumi packages will refer to this field while the bridge will translate it to terraform's original format.